### PR TITLE
fix: harden the startup path, the hook lifetime and the input hot path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,77 @@ the driver.
 This means most changes touch one of three things: the Win32/NT boundary, the
 hooks, or the per-event hot path. Read this file before opening a pull request.
 
+## Where things live
+
+| Path             | What is in it                                                     |
+| ---------------- | ----------------------------------------------------------------- |
+| `src/main.rs`    | Entry point and exit codes                                        |
+| `src/error.rs`   | The crate's error type; every failure path goes through it        |
+| `src/app/`       | Startup, shutdown, single-instance guard, and the menu actions     |
+| `src/driver/`    | Driver install and removal, virtual devices, IOCTLs, the watchdog  |
+| `src/redirect/`  | The hooks, the decision made per event, echo suppression, combos   |
+| `src/hid/`       | HID report formats, modifier flags, scan code tables               |
+| `src/ui/`        | Console output: layout, colours, the menu, keypress reading        |
+| `drivers/`       | The bundled signed driver package                                  |
+| `res/`           | Application manifest and icon resources                            |
+| `build.rs`       | Embeds the manifest and resources                                  |
+
+## Running it
+
+This is not a program that can be casually run to see what a change does:
+
+- Windows only, on `x86_64`. There is no cross-platform path and no stub.
+- The manifest requires administrator rights, so it will not start elevated by
+  accident - it either runs elevated or exits.
+- It installs a driver package into the system driver store, creates a root
+  device, and can ask for a reboot to finish. Uninstalling is a separate action
+  in the menu, not something that happens on exit.
+
+So verify changes with `cargo test` and CI. Treat an actual run as a deliberate
+act on a machine you are willing to have a driver installed on.
+
+## Before you push
+
+CI runs these, in this order, and fails the build on the first one that
+complains. Run them locally on Windows first:
+
+```
+cargo fmt --all --check
+cargo clippy --locked --all-targets -- -D warnings
+cargo test
+```
+
+Notes that catch people out:
+
+- **A new Win32 call needs its feature.** The `windows` crate is compiled with
+  an explicit feature list in `Cargo.toml`. Calling an API from a module that
+  is not in that list fails to compile with the item simply not existing - add
+  the feature in the same commit.
+- The `windows` crate is a moving target across versions. An associated
+  function that a tutorial or an older branch uses may no longer exist; check
+  what the pinned version actually provides rather than the name you expect.
+- `--locked` means `Cargo.lock` must already match `Cargo.toml`. Commit the
+  updated lock file together with any dependency change.
+- Clippy runs with `pedantic` and `-D warnings`. Among other things, an item
+  named in a doc comment has to be in backticks.
+- `rustfmt` runs with default settings, so an argument list wider than 60
+  characters gets split across lines even though the line fits in 100.
+- Every commit that lands on the branch should build on its own. Do not split a
+  signature change and its call sites into separate commits.
+
+## Build configuration
+
+These are pinned on purpose. A change here changes what ships, so it belongs in
+its own pull request with a reason:
+
+- `rust-toolchain.toml` pins the toolchain, and `Cargo.toml` states the minimum
+  supported version.
+- `.cargo/config.toml` sets the target to `x86_64-pc-windows-msvc` and links
+  the CRT statically, so the release binary runs without a redistributable. CI
+  checks the built executable for dynamic CRT imports.
+- The release profile uses fat LTO, one codegen unit, and strips symbols.
+- CI verifies the Authenticode signature of the bundled driver package.
+
 ## General requirements
 
 - Keep pull requests small and focused. One concern per pull request; if a
@@ -38,28 +109,6 @@ When a pull request spans several kinds of change, use the prefix that
 describes its purpose, not the largest part of the diff. Individual commits
 within the branch use the same prefixes.
 
-## Before you push
-
-CI runs these, in this order, and fails the build on the first one that
-complains. Run them locally on Windows first:
-
-```
-cargo fmt --all --check
-cargo clippy --locked --all-targets -- -D warnings
-cargo test
-```
-
-Notes that catch people out:
-
-- `--locked` means `Cargo.lock` must already match `Cargo.toml`. Commit the
-  updated lock file together with any dependency change.
-- Clippy runs with `pedantic` and `-D warnings`. Among other things, an item
-  named in a doc comment has to be in backticks.
-- `rustfmt` runs with default settings, so an argument list wider than 60
-  characters gets split across lines even though the line fits in 100.
-- Every commit that lands on the branch should build on its own. Do not split a
-  signature change and its call sites into separate commits.
-
 ## Code conventions
 
 - `unsafe_op_in_unsafe_fn` is denied. Every `unsafe` block carries a `SAFETY:`
@@ -76,6 +125,27 @@ Notes that catch people out:
 - Never let a panic cross an `extern "system"` boundary: unwinding out of a
   callback aborts the process, and an abort skips the destructors that release
   the virtual devices.
+
+## The driver interface is not ours to simplify
+
+`src/driver/ioctl.rs` describes a binary interface that belongs to the driver:
+request layouts, field offsets, packing, IOCTL codes, report descriptors, and
+the vendor and product ids the devices are published under. The driver reads
+these bytes at fixed positions.
+
+The assertions in that file are the specification. A layout that looks
+redundant, a padded field, or an odd struct size is the driver's requirement,
+not an oversight. If a change there is genuinely needed, the assertions must be
+updated deliberately and the reason stated - never relaxed to make a build pass.
+
+## Limits on what to change unasked
+
+- Do not edit `README.md` unless the change was asked for.
+- Do not add or upgrade a dependency without the matching `Cargo.lock` update
+  in the same commit.
+- Do not widen a diff beyond what was asked. If you notice something adjacent
+  that should change, say so instead of changing it.
+- Do not merge your own pull request.
 
 ## Things to leave alone
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,90 @@
+# Contributing to InputRedirect
+
+InputRedirect is a Windows-only, user-mode program that redirects keyboard and
+mouse input through a real, signed HID driver. It installs the driver, plugs in
+virtual devices, intercepts input with low-level hooks, and re-sends it through
+the driver.
+
+This means most changes touch one of three things: the Win32/NT boundary, the
+hooks, or the per-event hot path. Read this file before opening a pull request.
+
+## General requirements
+
+- Keep pull requests small and focused. One concern per pull request; if a
+  change needs a rename or a refactor to make sense, that is its own commit.
+- Explain the issue and why the change fixes it. A diff that only says what it
+  does cannot be reviewed - the reasoning is the part that has to be checked.
+- Before adding new functionality, make sure it does not already exist
+  elsewhere in the codebase. This project has small, purpose-built helpers
+  (path encoding, process lookup, device enumeration, handle wrappers) that are
+  easy to reinvent by accident.
+- English only, everywhere: commit messages, commit bodies, pull request titles
+  and descriptions, code, comments and documentation.
+
+## Pull request titles
+
+Titles follow conventional commit standards:
+
+| Prefix      | Use for                                              |
+| ----------- | ---------------------------------------------------- |
+| `feat:`     | new feature or functionality                         |
+| `fix:`      | bug fix                                              |
+| `docs:`     | documentation or README changes                      |
+| `chore:`    | maintenance tasks, dependency updates, etc.          |
+| `refactor:` | code refactoring without changing behaviour          |
+| `test:`     | adding or updating tests                             |
+
+When a pull request spans several kinds of change, use the prefix that
+describes its purpose, not the largest part of the diff. Individual commits
+within the branch use the same prefixes.
+
+## Before you push
+
+CI runs these, in this order, and fails the build on the first one that
+complains. Run them locally on Windows first:
+
+```
+cargo fmt --all --check
+cargo clippy --locked --all-targets -- -D warnings
+cargo test
+```
+
+Notes that catch people out:
+
+- `--locked` means `Cargo.lock` must already match `Cargo.toml`. Commit the
+  updated lock file together with any dependency change.
+- Clippy runs with `pedantic` and `-D warnings`. Among other things, an item
+  named in a doc comment has to be in backticks.
+- `rustfmt` runs with default settings, so an argument list wider than 60
+  characters gets split across lines even though the line fits in 100.
+- Every commit that lands on the branch should build on its own. Do not split a
+  signature change and its call sites into separate commits.
+
+## Code conventions
+
+- `unsafe_op_in_unsafe_fn` is denied. Every `unsafe` block carries a `SAFETY:`
+  comment stating why the call is sound - what owns the handle, who guarantees
+  the pointer, which thread it runs on.
+- Comments explain why, briefly. They are not a narration of the code.
+- Tests are named as sentences describing the property being pinned down, for
+  example `a_plug_refused_while_the_bus_catches_up_is_asked_again`.
+- Prefer RAII wrappers over paired open/close calls, and absolute paths over
+  anything Windows would resolve through `PATH`.
+- The hooks run on the system's input path. Work inside a hook callback is
+  latency for every keystroke on the machine, so nothing goes in there that can
+  block, allocate without need, or call out to Windows unnecessarily.
+- Never let a panic cross an `extern "system"` boundary: unwinding out of a
+  callback aborts the process, and an abort skips the destructors that release
+  the virtual devices.
+
+## Things to leave alone
+
+These look like oversights and are not. Changing them needs a reason in the
+pull request description:
+
+- The low-level hook architecture, and the choice not to redirect pointer
+  movement or the wheel.
+- The absence of `panic = "abort"` in the release profile.
+- The offset assertions in `src/driver/ioctl.rs`, which pin down the layout the
+  driver expects.
+- The Authenticode verification step in CI.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,6 @@
 version = 4
 
 [[package]]
-name = "anyhow"
-version = "1.0.104"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
-
-[[package]]
 name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -103,7 +97,6 @@ dependencies = [
 name = "input-redirect"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "bitflags",
  "embed-resource",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ name = "InputRedirect"
 path = "src/main.rs"
 
 [dependencies]
-anyhow = "1"
 bitflags = "2"
 tempfile = "3"
 thiserror = "2"
@@ -54,8 +53,8 @@ lto = "fat"
 codegen-units = 1
 strip = true
 
-# Groups are given a lower priority than the single lints below them, so the
-# individual settings win no matter how Cargo orders the table.
+# Groups take a lower priority than the single lints below them, so the
+# individual settings win whatever order Cargo reads the table in.
 [lints.rust]
 rust_2018_idioms = { level = "warn", priority = -1 }
 unsafe_op_in_unsafe_fn = "deny"
@@ -64,30 +63,26 @@ unsafe_op_in_unsafe_fn = "deny"
 all = { level = "warn", priority = -1 }
 pedantic = { level = "warn", priority = -1 }
 
-# The Win32 surface is full of casts and wide pointers; forbidding them here
-# would only produce noise around calls we cannot express any other way.
+# The Win32 surface is casts and wide pointers throughout; forbidding them
+# would only add noise to calls we cannot write any other way.
 cast_possible_truncation = "allow"
 cast_sign_loss = "allow"
 missing_errors_doc = "allow"
 
-# Almost every Win32 call takes an out parameter, and `&mut value` reads far
-# better at those call sites than `&raw mut value`.
+# Win32 out parameters read better as `&mut value` than `&raw mut value`.
 borrow_as_ptr = "allow"
 
-# Counting a handful of bytes in a report descriptor does not justify pulling
-# in the bytecount crate.
+# Counting a few bytes of a report descriptor does not justify a crate.
 naive_bytecount = "allow"
 
-# The embedded driver file names are fixed strings we write ourselves, so a
-# plain suffix check is exactly right.
+# The driver file names are fixed strings we write ourselves.
 case_sensitive_file_extension_comparisons = "allow"
 
-# The dashboard really is a handful of independent switches; turning each of
-# them into an enum would make the drawing code harder to read, not easier.
+# The dashboard really is a handful of independent switches.
 struct_excessive_bools = "allow"
 
-# Drawing and locking helpers stay methods so the call sites read as one
-# object doing the work, even when they do not touch any field.
+# Drawing and locking helpers stay methods so the call sites read as one object
+# doing the work, even when they touch no field.
 unused_self = "allow"
 
 # Matching on a Result and cleaning up in the error arm is clearer than an

--- a/src/driver/device.rs
+++ b/src/driver/device.rs
@@ -35,6 +35,32 @@ const CORE_INTERFACE: GUID = GUID::from_u128(0x1abc_05c0_c378_41b9_9cef_df1a_ba8
 /// there is no reliable thing to look at in between.
 const PLUG_SETTLE: Duration = Duration::from_millis(200);
 
+/// A device information set that Windows takes back when it goes out of scope.
+///
+/// The set holds enumeration state on the kernel side, and every user of one is
+/// a loop with early exits in it, so the destroy call belongs to the scope
+/// rather than to a line at the end of it.
+pub(super) struct DeviceInfoSet(HDEVINFO);
+
+impl DeviceInfoSet {
+    pub(super) fn new(set: HDEVINFO) -> Self {
+        Self(set)
+    }
+
+    pub(super) fn handle(&self) -> HDEVINFO {
+        self.0
+    }
+}
+
+impl Drop for DeviceInfoSet {
+    fn drop(&mut self) {
+        // SAFETY: the set came from SetupDi and is destroyed exactly once.
+        unsafe {
+            let _ = SetupDiDestroyDeviceInfoList(self.0);
+        }
+    }
+}
+
 /// The id the driver hands back for a device it created.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct VirtualDeviceId(u32);
@@ -99,11 +125,10 @@ impl Devices {
 
     /// Creates one virtual device and reads back the id the driver gave it.
     ///
-    /// The id can come back as zero, which means the driver created the device
-    /// but did not say which one it is. That is not treated as a failure here -
-    /// the device does work - but it cannot be asked for by id afterwards, so
-    /// [`Self::unplug`] turns it into a refusal and the caller falls back to
-    /// taking the device off the bus the hard way.
+    /// The id can come back as zero, meaning the driver created the device but
+    /// did not say which one it is. The device works, but it cannot be asked
+    /// for by id afterwards, so [`Self::unplug`] turns that into a refusal and
+    /// the caller takes the device off the bus the hard way.
     fn plug(&self, kind: DeviceKind) -> Result<VirtualDeviceId> {
         let handle = self.handle()?;
         let mut payload = ioctl::plug_payload(kind);
@@ -123,14 +148,12 @@ impl Devices {
 
     /// Asks the driver to take a virtual device away.
     ///
-    /// The answer is returned rather than dropped, because it decides what has
-    /// to happen next: a device the driver still owns keeps its product id, and
-    /// the next plug of the same device is answered with an invalid parameter
-    /// that says nothing about the real reason.
+    /// The answer decides what happens next: a device the driver still owns
+    /// keeps its product id, and the next plug of the same device is refused
+    /// with an invalid parameter that says nothing about the real reason.
     pub fn unplug(&self, id: VirtualDeviceId) -> Result<()> {
         // Zero is not an id the driver ever handed out - it is what is read
-        // back when the driver named nothing - so there is nothing to ask for
-        // here, and asking would only be refused.
+        // back when the driver named nothing - so there is nothing to ask for.
         if id.0 == 0 {
             return Err(Error::Device(
                 "the driver never said which device it created".to_owned(),
@@ -214,8 +237,8 @@ fn open_native(path: &str) -> Option<HANDLE> {
 fn interface_paths(interface: &GUID) -> Vec<String> {
     let mut paths = Vec::new();
 
-    // SAFETY: the device information set is destroyed before returning, and
-    // every buffer handed to SetupDi is sized from the size it asked for.
+    // SAFETY: every buffer handed to SetupDi is sized from the size it asked
+    // for, and the set outlives the calls that read from it.
     unsafe {
         let Ok(set) = SetupDiGetClassDevsW(
             Some(interface),
@@ -225,6 +248,7 @@ fn interface_paths(interface: &GUID) -> Vec<String> {
         ) else {
             return paths;
         };
+        let set = DeviceInfoSet::new(set);
 
         let mut index = 0;
         loop {
@@ -232,13 +256,21 @@ fn interface_paths(interface: &GUID) -> Vec<String> {
                 cbSize: std::mem::size_of::<SP_DEVICE_INTERFACE_DATA>() as u32,
                 ..Default::default()
             };
-            if SetupDiEnumDeviceInterfaces(set, None, interface, index, &mut data).is_err() {
+            if SetupDiEnumDeviceInterfaces(set.handle(), None, interface, index, &mut data).is_err()
+            {
                 break;
             }
             index += 1;
 
             let mut needed = 0;
-            let _ = SetupDiGetDeviceInterfaceDetailW(set, &data, None, 0, Some(&mut needed), None);
+            let _ = SetupDiGetDeviceInterfaceDetailW(
+                set.handle(),
+                &data,
+                None,
+                0,
+                Some(&mut needed),
+                None,
+            );
             if needed == 0 {
                 continue;
             }
@@ -253,8 +285,15 @@ fn interface_paths(interface: &GUID) -> Vec<String> {
                 .cast::<SP_DEVICE_INTERFACE_DETAIL_DATA_W>();
             (*detail).cbSize = std::mem::size_of::<SP_DEVICE_INTERFACE_DETAIL_DATA_W>() as u32;
 
-            if SetupDiGetDeviceInterfaceDetailW(set, &data, Some(detail), needed, None, None)
-                .is_ok()
+            if SetupDiGetDeviceInterfaceDetailW(
+                set.handle(),
+                &data,
+                Some(detail),
+                needed,
+                None,
+                None,
+            )
+            .is_ok()
             {
                 let text = PCWSTR((*detail).DevicePath.as_ptr()).to_string();
                 if let Ok(path) = text {
@@ -262,8 +301,6 @@ fn interface_paths(interface: &GUID) -> Vec<String> {
                 }
             }
         }
-
-        let _ = SetupDiDestroyDeviceInfoList(HDEVINFO(set.0));
     }
 
     paths
@@ -294,6 +331,15 @@ mod tests {
         let native = r"\??\ROOT#SYSTEM#0002#{1abc05c0}";
 
         assert_eq!(to_native_path(native), native);
+    }
+
+    /// Enumerating an interface nobody publishes has to end quietly, and the
+    /// set it opened along the way has to be given back.
+    #[test]
+    fn an_interface_nobody_publishes_yields_no_paths() {
+        let nobody = GUID::from_u128(0x0000_0000_dead_4000_8000_0000_0000_0001);
+
+        assert!(interface_paths(&nobody).is_empty());
     }
 
     /// The refusal is what tells the caller to take the device off the bus

--- a/src/driver/ghub.rs
+++ b/src/driver/ghub.rs
@@ -47,7 +47,9 @@ pub fn stop() {
     let _ = service::stop(UPDATER_SERVICE);
 
     for their_process in theirs() {
-        process::terminate(their_process);
+        // The same question is asked again inside, of the handle rather than
+        // the id: this list is a moment old, and ids are handed out again.
+        process::terminate(their_process, is_theirs);
     }
 }
 
@@ -135,6 +137,21 @@ mod tests {
         assert!(!is_theirs("lghub_agent.exe.bak"));
         assert!(!is_theirs("my_lghub_agent.exe"));
         assert!(!is_theirs("notepad.exe"));
+    }
+
+    /// The predicate the watchdog closes processes with must not accept the
+    /// program running it, whatever happens to the ids in between.
+    #[test]
+    fn the_watchdog_would_not_close_this_program() {
+        let ours = std::env::current_exe()
+            .ok()
+            .and_then(|path| {
+                path.file_name()
+                    .map(|name| name.to_string_lossy().to_string())
+            })
+            .unwrap_or_default();
+
+        assert!(!is_theirs(&ours));
     }
 
     #[test]

--- a/src/driver/ghub.rs
+++ b/src/driver/ghub.rs
@@ -1,18 +1,16 @@
 //! Logitech G HUB, which wants the same two virtual devices we do.
 //!
-//! G HUB plugs its own virtual keyboard and mouse through the same driver, with
-//! the very product ids this program asks for, and a product id can only be
-//! taken once. While its agent runs, our plug is turned down with an invalid
-//! parameter - the same answer the driver gives for a request it cannot read at
-//! all - so there is nothing in the failure that points at the real reason.
+//! G HUB plugs its own virtual keyboard and mouse with the very product ids
+//! this program asks for, and a product id can only be taken once. While its
+//! agent runs, our plug is turned down with an invalid parameter - the same
+//! answer the driver gives for a request it cannot read at all.
 //!
 //! Closing the agent once is not enough: its updater service starts it again a
-//! moment later. So the service is asked to stop first, and a watchdog keeps
-//! looking for as long as this program runs.
+//! moment later. So the service is stopped first, and a watchdog keeps looking
+//! for as long as this program runs.
 //!
-//! Nothing of the user's is lost by this. Profiles, macros, lighting and pointer
-//! settings live in the application's own files, not in the driver; they are
-//! applied again the next time G HUB is started.
+//! Nothing of the user's is lost: profiles, macros and lighting live in the
+//! application's own files and are applied again the next time it runs.
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -33,9 +31,8 @@ const PROCESSES: [&str; 4] = [
 /// The service that starts the agent again on its own.
 const UPDATER_SERVICE: &str = "LGHUBUpdaterService";
 
-/// How long the watchdog waits between looks, and in how small a step it waits.
-/// The step is what makes stopping it feel immediate instead of costing a whole
-/// interval.
+/// How long the watchdog waits between looks, and in how small a step. The step
+/// is what makes stopping it feel immediate.
 const WATCH_INTERVAL: Duration = Duration::from_secs(1);
 const WATCH_STEP: Duration = Duration::from_millis(100);
 
@@ -46,8 +43,7 @@ pub fn is_running() -> bool {
 
 /// Stops the updater service and closes every process of G HUB that is up.
 pub fn stop() {
-    // The service first: closing the agent while its updater is running only
-    // buys a second.
+    // The service first: closing the agent while its updater runs buys a second.
     let _ = service::stop(UPDATER_SERVICE);
 
     for their_process in theirs() {
@@ -56,7 +52,7 @@ pub fn stop() {
 }
 
 /// Keeps G HUB closed for as long as this value is alive. Dropping it stops the
-/// thread and waits for it, so nothing of ours is left looking after us.
+/// thread and waits for it.
 pub struct Watchdog {
     watching: Arc<AtomicBool>,
     thread: Option<JoinHandle<()>>,
@@ -93,7 +89,7 @@ impl Drop for Watchdog {
 }
 
 /// Waits out one interval in short steps. False means the watchdog was asked to
-/// stop while it waited, and the caller should not look again.
+/// stop while it waited.
 fn wait(watching: &AtomicBool) -> bool {
     let mut waited = Duration::ZERO;
 
@@ -143,8 +139,7 @@ mod tests {
 
     #[test]
     fn asking_which_of_their_processes_are_running_changes_nothing() {
-        // On a machine without G HUB both answers are empty, and on one with it
-        // they are the same list: looking must never close anything.
+        // Looking must never close anything.
         assert_eq!(theirs().len(), theirs().len());
     }
 
@@ -154,7 +149,7 @@ mod tests {
         drop(watchdog);
 
         // Getting here at all is the assertion: a watchdog that outlived its
-        // owner, or one that was never joined, would hang this test.
+        // owner would hang this test.
         let watching = AtomicBool::new(false);
         assert!(!wait(&watching));
     }

--- a/src/driver/install.rs
+++ b/src/driver/install.rs
@@ -23,7 +23,7 @@ use windows::Win32::Devices::DeviceAndDriverInstallation::{
 
 use crate::error::{Error, Result};
 
-use super::{holders, process, service, version, wide};
+use super::{holders, process, service, system32, version, wide};
 
 /// The device the bus driver binds to. It does not exist until we create it.
 const ROOT_HARDWARE_ID: &str = r"root\LGHUBVirtualBus";
@@ -33,27 +33,24 @@ const SYSTEM_DEVICE_CLASS: windows::core::GUID =
 const BUS_PACKAGE: &str = "logi_joy_bus_enum.inf";
 const HID_PACKAGE: &str = "logi_joy_vir_hid.inf";
 
-/// What the plug and play utility answers with when it has done the work but a
-/// restart is needed to finish it. The store is up to date either way; what is
-/// left over is the copy the kernel already has open. That is a success when
-/// nothing needs the new files right now - removing the driver, above all - and
-/// not when the whole point was to have the new build answering, which is why
-/// the answer is carried out of here rather than dropped.
+/// What the plug and play utility answers when it has done the work but a
+/// restart is needed to finish it.
+///
+/// The store is up to date either way; what is left over is the copy the kernel
+/// already has open. That is a success when nothing needs the new files right
+/// now, and not when the whole point was to have the new build answering -
+/// which is why the answer is carried out of here rather than dropped.
 const RESTART_TO_FINISH: i32 = 3010;
 
 /// How long the plug and play utility is given to finish.
 ///
-/// It normally answers in a second or two, and a minute is generous even on a
-/// slow machine with a large driver store. What this is really for is the case
-/// where it never answers at all: without a deadline the program hung on its way
-/// up, showing the step it had reached and nothing else, and the only way out
-/// was the task manager.
+/// It normally answers in a second or two. The deadline is for the case where
+/// it never answers at all: without one the program hung on its way up, and the
+/// only way out was the task manager.
 const INSTALLER_TIMEOUT: Duration = Duration::from_secs(60);
 
-/// How long the services are given to come up, and how often to look. Plug and
-/// play starts them in the background, so this is a wait for something to
-/// happen rather than a pause in the hope that it did: on a machine where it
-/// takes 200 ms, that is what it costs.
+/// How long the services are given to come up, and how often to look. A wait
+/// for something to happen rather than a pause in the hope that it did.
 const STARTUP_TIMEOUT: Duration = Duration::from_secs(3);
 const STARTUP_POLL: Duration = Duration::from_millis(50);
 
@@ -105,15 +102,12 @@ fn add_packages(drivers: &Path) -> Result<Finished> {
 /// Makes sure the build now answering is the one this program speaks to.
 ///
 /// Windows says "done, after a restart" when it could not put a file in place
-/// because the kernel still has the old one open. The services are running
-/// either way, so nothing else notices - but they are running the old images,
-/// which answer the requests this program sends with the same invalid parameter
-/// they use for a device that is merely busy. Walking into that leaves the user
-/// with a failure that names nothing and repeats on every start.
+/// because the kernel still has the old one open. The services run either way,
+/// but on the old images, which answer our requests with the same invalid
+/// parameter they use for a device that is merely busy.
 ///
-/// Reading the version back is what tells the two apart: Windows often lands
-/// the new file at once and defers only the deletion of the old one, and then
-/// there is nothing to wait for.
+/// Reading the version back tells the two apart: Windows often lands the new
+/// file at once and defers only the deletion of the old one.
 fn is_the_build_we_speak_to(drivers: &Path, finished: Finished) -> Result<()> {
     if finished == Finished::Now {
         return Ok(());
@@ -131,17 +125,14 @@ fn is_the_build_we_speak_to(drivers: &Path, finished: Finished) -> Result<()> {
 
 /// Puts our build of the package in place of whichever one is installed.
 ///
-/// The store is emptied of both packages first and ours added afterwards. They
-/// carry the same file names whatever build they come from, so there is no way
-/// to remove one and keep the other, and a package left behind can be ranked
-/// above ours the next time plug and play looks for a driver for a device.
+/// Both packages are removed first and ours added afterwards: they carry the
+/// same file names whatever build they come from, and a package left behind can
+/// be ranked above ours the next time plug and play looks for a driver.
 ///
-/// A step that only finishes after a restart is not treated as done here, the
-/// way it is when the driver is being removed. Windows says that when it cannot
-/// touch a file the kernel still holds, and the images that go on answering are
-/// then the old ones - which is exactly the situation this function exists to
-/// get out of. Whether that really happened is read back from the files
-/// afterwards rather than assumed from the answer.
+/// Unlike a removal, a step that only finishes after a restart is not treated
+/// as done here - the old images would go on answering, which is the situation
+/// this function exists to get out of. Whether that happened is read back from
+/// the files rather than assumed from the answer.
 pub fn replace(drivers: &Path) -> Result<()> {
     service::stop_all();
 
@@ -167,10 +158,8 @@ pub fn replace(drivers: &Path) -> Result<()> {
         finished = Finished::AfterRestart;
     }
 
-    // Both halves of the replacement can be put off to the next start, and
-    // either one leaves the old build answering. This is the one path where
-    // that matters enough to stop for: the whole reason to replace a driver
-    // that is already installed is that its protocol is not the one we speak.
+    // Either half of the replacement can be put off to the next start, and
+    // either one leaves the old build answering.
     is_the_build_we_speak_to(drivers, finished)
 }
 
@@ -200,8 +189,7 @@ pub fn bind_root_device(drivers: &Path) -> Result<()> {
     let hardware_id = wide(ROOT_HARDWARE_ID);
 
     // SAFETY: both strings are null terminated and outlive the call. The
-    // reboot-required flag is optional and was never read, so it is not asked
-    // for.
+    // reboot-required flag is optional and was never read.
     unsafe {
         UpdateDriverForPlugAndPlayDevicesW(
             None,
@@ -271,16 +259,14 @@ enum Leftovers {
 
 /// How many child devices of a previous session are still on the bus.
 ///
-/// Waiting for this to reach zero is the difference between knowing the bus has
-/// finished taking a device away and hoping that it has: a device that is still
-/// there holds its product id, and the next device asked for with that id is
-/// turned down.
+/// A device that is still there holds its product id, and the next device asked
+/// for with that id is turned down.
 pub fn leftover_devices() -> i32 {
     visit_leftover_devices(Leftovers::Count)
 }
 
 /// Removes the child devices a previous session left behind, and reports how
-/// many were actually taken away - a device that refused to go is not counted.
+/// many were actually taken away.
 pub fn remove_leftover_devices() -> i32 {
     visit_leftover_devices(Leftovers::Remove)
 }
@@ -288,14 +274,12 @@ pub fn remove_leftover_devices() -> i32 {
 fn visit_leftover_devices(action: Leftovers) -> i32 {
     let mut found = 0;
 
-    // Counting asks only about devices that are really on the bus, because only
-    // those still hold a product id the next plug needs. Windows keeps the
-    // registry entry of a child long after the bus stops reporting it, and
-    // counting those ghosts too meant the wait for an empty bus could never
-    // succeed: every re-creation sat out its timeout and then rebuilt the bus.
+    // Counting asks only about devices really on the bus, because only those
+    // hold a product id. Windows keeps the registry entry of a child long after
+    // the bus stops reporting it, and counting those ghosts meant the wait for
+    // an empty bus could never succeed.
     //
-    // Removing deliberately asks about all of them, ghosts included - clearing
-    // out what earlier sessions left behind is the whole point of that pass.
+    // Removing deliberately asks about all of them, ghosts included.
     let scope = match action {
         Leftovers::Count => DIGCF_ALLCLASSES | DIGCF_PRESENT,
         Leftovers::Remove => DIGCF_ALLCLASSES,
@@ -351,11 +335,9 @@ pub fn uninstall() -> Result<()> {
         let output = pnputil(["/delete-driver", &published_name, "/uninstall", "/force"])?;
 
         // A removal that only finishes after a restart still counts as done:
-        // the copy left behind is the one the kernel already has open, and that
-        // is exactly what removing a driver that is still loaded looks like. The
-        // same 3010 `replace` and `add_package` accept as success - treating it
-        // as a failure here reported every ordinary removal as broken and never
-        // set the restart-pending flag the removal flow is built around.
+        // the copy left behind is the one the kernel already has open, which is
+        // exactly what removing a loaded driver looks like. Treating it as a
+        // failure reported every ordinary removal as broken.
         let code = output.status.code().unwrap_or(-1);
         if code != 0 && code != RESTART_TO_FINISH {
             return Err(Error::Uninstall(format!(
@@ -374,11 +356,8 @@ fn blamed() -> String {
     blame(&holders::of(&version::installed_binaries()))
 }
 
-/// The wording, kept apart from the asking so that it can be read at a glance
-/// and tested without a driver on the machine.
-///
-/// A failure with nobody to blame says nothing extra: a sentence ending in
-/// "held by" and then nothing would read like a bug of its own.
+/// The wording, kept apart from the asking so it can be tested without a driver
+/// on the machine. A failure with nobody to blame says nothing extra.
 fn blame(holders: &[String]) -> String {
     if holders.is_empty() {
         String::new()
@@ -391,9 +370,7 @@ fn blame(holders: &[String]) -> String {
 ///
 /// The driver database is asked first: it is indexed by our own .inf file names
 /// and holds nothing that depends on the display language of Windows. The
-/// listing printed by the plug and play utility is only read when the database
-/// has nothing to say, so a machine that keeps it somewhere else still has a
-/// way to have the driver removed.
+/// printed listing is only read when the database has nothing to say.
 fn our_published_names() -> Result<Vec<String>> {
     let from_database: Vec<String> = [BUS_PACKAGE, HID_PACKAGE]
         .into_iter()
@@ -426,12 +403,11 @@ fn add_package(path: &Path) -> Result<Finished> {
 
 /// Runs the plug and play utility and waits for it, but not forever.
 ///
-/// The output is read on a thread of its own instead of after the wait. A pipe
-/// that fills up stops the program writing into it, so a wait that is not
-/// reading at the same time would be waiting for a process that is waiting for
-/// us - and neither would ever move again.
+/// The output is read on a thread of its own. A pipe that fills up stops the
+/// program writing into it, so a wait that is not reading at the same time
+/// would be waiting for a process that is waiting for us.
 fn pnputil<const N: usize>(arguments: [&str; N]) -> Result<Output> {
-    let child = Command::new("pnputil.exe")
+    let child = Command::new(system32("pnputil.exe"))
         .args(arguments)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
@@ -480,9 +456,8 @@ struct Package {
 
 impl Package {
     /// The file name is compared without regard to case: Windows file names are
-    /// case insensitive, the listing repeats whatever case the package was
-    /// added with, and mistaking our own package for someone else's would leave
-    /// the user unable to remove the driver at all.
+    /// case insensitive, and mistaking our own package for someone else's would
+    /// leave the user unable to remove the driver at all.
     fn is_ours(&self) -> bool {
         [BUS_PACKAGE, HID_PACKAGE]
             .into_iter()
@@ -494,16 +469,13 @@ impl Package {
 /// Parses the listing the plug and play utility prints. Records are separated
 /// by blank lines and every field is `label: value`.
 ///
-/// The labels are deliberately ignored. Windows translates them, so on a
-/// Russian or Ukrainian machine they are not the words this program could have
-/// been written against, and a parser that matched them would report an empty
-/// driver store and refuse to remove anything. What does not change is the
-/// order of the fields and the values themselves: `oem49.inf`, `Logitech` and
-/// the .inf file names read the same in every language.
+/// The labels are deliberately ignored: Windows translates them, and a parser
+/// that matched them would report an empty driver store on a Russian or
+/// Ukrainian machine. The order of the fields and the values themselves read
+/// the same in every language.
 ///
 /// A record therefore starts at the first value that names an .inf file, which
-/// is what separates the records from the heading the utility prints above
-/// them - in whatever language it prints it.
+/// is what separates the records from the heading printed above them.
 fn parse_packages(listing: &str) -> Vec<Package> {
     let mut packages = Vec::new();
     let mut values: Vec<&str> = Vec::new();
@@ -535,8 +507,7 @@ fn parse_packages(listing: &str) -> Vec<Package> {
 }
 
 /// The first three values of a record are the published name, the original name
-/// and the provider, in that order. Everything after them describes the package
-/// rather than naming it, and a record with fewer than three is not one.
+/// and the provider, in that order. A record with fewer than three is not one.
 fn package_from(values: &[&str]) -> Option<Package> {
     let [published_name, original_name, provider, ..] = values else {
         return None;
@@ -595,9 +566,7 @@ mod tests {
 
     const LISTING: &str = "Microsoft PnP Utility\n\nPublished Name:     oem49.inf\nOriginal Name:      logi_joy_bus_enum.inf\nProvider Name:      Logitech\nClass Name:         System devices\nDriver Version:     09/02/2022 2022.3.0.2\n\nPublished Name:     oem50.inf\nOriginal Name:      logi_joy_vir_hid.inf\nProvider Name:      Logitech\nClass Name:         HIDClass\n\nPublished Name:     oem12.inf\nOriginal Name:      nvidia_display.inf\nProvider Name:      NVIDIA\nClass Name:         Display\n";
 
-    /// The same three records with Russian labels and a Russian heading. The
-    /// exact wording does not matter to the parser - that is the point of the
-    /// test - but it is written the way Windows prints it.
+    /// The same three records with Russian labels and a Russian heading.
     const RUSSIAN_LISTING: &str = "\u{41f}\u{440}\u{43e}\u{433}\u{440}\u{430}\u{43c}\u{43c}\u{430} Microsoft PnP Utility\n\n\u{41e}\u{43f}\u{443}\u{431}\u{43b}\u{438}\u{43a}\u{43e}\u{432}\u{430}\u{43d}\u{43d}\u{43e}\u{435} \u{438}\u{43c}\u{44f}:     oem49.inf\n\u{418}\u{441}\u{445}\u{43e}\u{434}\u{43d}\u{43e}\u{435} \u{438}\u{43c}\u{44f}:            logi_joy_bus_enum.inf\n\u{418}\u{43c}\u{44f} \u{43f}\u{43e}\u{441}\u{442}\u{430}\u{432}\u{449}\u{438}\u{43a}\u{430}:        Logitech\n\u{418}\u{43c}\u{44f} \u{43a}\u{43b}\u{430}\u{441}\u{441}\u{430}:           \u{421}\u{438}\u{441}\u{442}\u{435}\u{43c}\u{43d}\u{44b}\u{435} \u{443}\u{441}\u{442}\u{440}\u{43e}\u{439}\u{441}\u{442}\u{432}\u{430}\n\u{412}\u{435}\u{440}\u{441}\u{438}\u{44f} \u{434}\u{440}\u{430}\u{439}\u{432}\u{435}\u{440}\u{430}:      02.09.2022 14:30:00\n\n\u{41e}\u{43f}\u{443}\u{431}\u{43b}\u{438}\u{43a}\u{43e}\u{432}\u{430}\u{43d}\u{43d}\u{43e}\u{435} \u{438}\u{43c}\u{44f}:     oem50.inf\n\u{418}\u{441}\u{445}\u{43e}\u{434}\u{43d}\u{43e}\u{435} \u{438}\u{43c}\u{44f}:            logi_joy_vir_hid.inf\n\u{418}\u{43c}\u{44f} \u{43f}\u{43e}\u{441}\u{442}\u{430}\u{432}\u{449}\u{438}\u{43a}\u{430}:        Logitech\n\n\u{41e}\u{43f}\u{443}\u{431}\u{43b}\u{438}\u{43a}\u{43e}\u{432}\u{430}\u{43d}\u{43d}\u{43e}\u{435} \u{438}\u{43c}\u{44f}:     oem12.inf\n\u{418}\u{441}\u{445}\u{43e}\u{434}\u{43d}\u{43e}\u{435} \u{438}\u{43c}\u{44f}:            nvidia_display.inf\n\u{418}\u{43c}\u{44f} \u{43f}\u{43e}\u{441}\u{442}\u{430}\u{432}\u{449}\u{438}\u{43a}\u{430}:        NVIDIA\n";
 
     /// The bus package on a Ukrainian machine.
@@ -647,8 +616,7 @@ mod tests {
 
     #[test]
     fn a_time_in_a_later_field_does_not_disturb_the_record_it_belongs_to() {
-        // A localised date field holds colons of its own. Only the first three
-        // values of a record are used, so it cannot reach the names.
+        // A localised date field holds colons of its own.
         let packages = parse_packages(RUSSIAN_LISTING);
 
         assert_eq!(packages[0].published_name, "oem49.inf");
@@ -713,16 +681,14 @@ mod tests {
         assert!(parse_packages("Microsoft PnP Utility\n\n").is_empty());
     }
 
-    /// Counting must not remove anything, which is the whole reason the two
-    /// share one enumeration: on a machine without the driver both answer zero,
-    /// and counting twice keeps answering the same.
+    /// Counting must not remove anything: on a machine without the driver both
+    /// answer zero, and counting twice keeps answering the same.
     #[test]
     fn counting_the_leftover_devices_leaves_them_where_they_are() {
         assert_eq!(leftover_devices(), leftover_devices());
     }
 
-    /// Windows did the work there and then, so there is nothing to check and
-    /// nothing to read off the disk.
+    /// Windows did the work there and then, so there is nothing to read.
     #[test]
     fn an_installation_that_finished_now_is_not_waiting_on_a_restart() {
         let answer = is_the_build_we_speak_to(Path::new(r"Z:\no\such\folder"), Finished::Now);
@@ -732,8 +698,7 @@ mod tests {
 
     /// A deferred installation is only a reason to stop if the build that
     /// answers is still the wrong one. Where neither version can be read there
-    /// is no evidence of that, and sending someone to restart on a guess is
-    /// worse than carrying on.
+    /// is no evidence of that.
     #[test]
     fn a_deferred_installation_with_nothing_to_compare_carries_on() {
         let answer =
@@ -742,8 +707,7 @@ mod tests {
         assert!(answer.is_ok());
     }
 
-    /// The message names both builds, because "restart the computer" without a
-    /// reason is the kind of advice nobody acts on.
+    /// "Restart the computer" without a reason is advice nobody acts on.
     #[test]
     fn a_restart_that_is_really_owed_says_which_build_is_in_the_way() {
         let error = Error::RestartRequired(format!(
@@ -777,8 +741,8 @@ mod tests {
         );
     }
 
-    /// The whole message the user is left with has to read as one sentence,
-    /// because that is how it reaches them: a code, then who is in the way.
+    /// The whole message has to read as one sentence: a code, then who is in
+    /// the way.
     #[test]
     fn a_failure_with_its_blame_reads_as_one_sentence() {
         let holders = vec!["System (process 4)".to_owned()];

--- a/src/driver/install.rs
+++ b/src/driver/install.rs
@@ -24,7 +24,7 @@ use windows::Win32::Devices::DeviceAndDriverInstallation::{
 use crate::error::{Error, Result};
 
 use super::device::DeviceInfoSet;
-use super::{holders, process, service, system32, version, wide};
+use super::{holders, process, service, system32, version, wide, wide_path};
 
 /// The device the bus driver binds to. It does not exist until we create it.
 const ROOT_HARDWARE_ID: &str = r"root\LGHUBVirtualBus";
@@ -185,7 +185,7 @@ pub fn bind_root_device(drivers: &Path) -> Result<()> {
         create_root_device()?;
     }
 
-    let inf = wide(&drivers.join(BUS_PACKAGE).display().to_string());
+    let inf = wide_path(&drivers.join(BUS_PACKAGE));
     let hardware_id = wide(ROOT_HARDWARE_ID);
 
     // SAFETY: both strings are null terminated and outlive the call. The

--- a/src/driver/install.rs
+++ b/src/driver/install.rs
@@ -33,6 +33,9 @@ const SYSTEM_DEVICE_CLASS: windows::core::GUID =
 const BUS_PACKAGE: &str = "logi_joy_bus_enum.inf";
 const HID_PACKAGE: &str = "logi_joy_vir_hid.inf";
 
+/// The plug and play utility, which is only ever the one in System32.
+const INSTALLER: &str = "pnputil.exe";
+
 /// What the plug and play utility answers when it has done the work but a
 /// restart is needed to finish it.
 ///
@@ -407,7 +410,7 @@ fn add_package(path: &Path) -> Result<Finished> {
 /// program writing into it, so a wait that is not reading at the same time
 /// would be waiting for a process that is waiting for us.
 fn pnputil<const N: usize>(arguments: [&str; N]) -> Result<Output> {
-    let child = Command::new(system32("pnputil.exe"))
+    let child = Command::new(system32(INSTALLER))
         .args(arguments)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
@@ -431,7 +434,9 @@ fn pnputil<const N: usize>(arguments: [&str; N]) -> Result<Output> {
         Err(_) => {
             // Nothing is owed to a utility that stopped answering, and leaving
             // it running would hold the driver store against the next attempt.
-            process::terminate(id);
+            // A minute has passed since it was started, so the id is only
+            // closed if it still names the utility we started.
+            process::terminate(id, |name| name.eq_ignore_ascii_case(INSTALLER));
 
             Err(Error::Install(format!(
                 "the system installer did not finish within {} seconds",

--- a/src/driver/install.rs
+++ b/src/driver/install.rs
@@ -15,14 +15,15 @@ use std::time::{Duration, Instant};
 use windows::core::PCWSTR;
 use windows::Win32::Devices::DeviceAndDriverInstallation::{
     SetupDiCallClassInstaller, SetupDiCreateDeviceInfoList, SetupDiCreateDeviceInfoW,
-    SetupDiDestroyDeviceInfoList, SetupDiEnumDeviceInfo, SetupDiGetClassDevsW,
-    SetupDiGetDeviceInstanceIdW, SetupDiRemoveDevice, SetupDiSetDeviceRegistryPropertyW,
-    UpdateDriverForPlugAndPlayDevicesW, DICD_GENERATE_ID, DIF_REGISTERDEVICE, DIGCF_ALLCLASSES,
-    DIGCF_PRESENT, HDEVINFO, INSTALLFLAG_FORCE, SPDRP_HARDWAREID, SP_DEVINFO_DATA,
+    SetupDiEnumDeviceInfo, SetupDiGetClassDevsW, SetupDiGetDeviceInstanceIdW, SetupDiRemoveDevice,
+    SetupDiSetDeviceRegistryPropertyW, UpdateDriverForPlugAndPlayDevicesW, DICD_GENERATE_ID,
+    DIF_REGISTERDEVICE, DIGCF_ALLCLASSES, DIGCF_PRESENT, INSTALLFLAG_FORCE, SPDRP_HARDWAREID,
+    SP_DEVINFO_DATA,
 };
 
 use crate::error::{Error, Result};
 
+use super::device::DeviceInfoSet;
 use super::{holders, process, service, system32, version, wide};
 
 /// The device the bus driver binds to. It does not exist until we create it.
@@ -45,15 +46,12 @@ const INSTALLER: &str = "pnputil.exe";
 /// which is why the answer is carried out of here rather than dropped.
 const RESTART_TO_FINISH: i32 = 3010;
 
-/// How long the plug and play utility is given to finish.
-///
-/// It normally answers in a second or two. The deadline is for the case where
-/// it never answers at all: without one the program hung on its way up, and the
-/// only way out was the task manager.
+/// How long the plug and play utility is given to finish. It normally answers
+/// in a second or two; the deadline is for the case where it never answers at
+/// all, which used to hang the program on its way up.
 const INSTALLER_TIMEOUT: Duration = Duration::from_secs(60);
 
-/// How long the services are given to come up, and how often to look. A wait
-/// for something to happen rather than a pause in the hope that it did.
+/// How long the services are given to come up, and how often to look.
 const STARTUP_TIMEOUT: Duration = Duration::from_secs(3);
 const STARTUP_POLL: Duration = Duration::from_millis(50);
 
@@ -134,8 +132,7 @@ fn is_the_build_we_speak_to(drivers: &Path, finished: Finished) -> Result<()> {
 ///
 /// Unlike a removal, a step that only finishes after a restart is not treated
 /// as done here - the old images would go on answering, which is the situation
-/// this function exists to get out of. Whether that happened is read back from
-/// the files rather than assumed from the answer.
+/// this function exists to get out of.
 pub fn replace(drivers: &Path) -> Result<()> {
     service::stop_all();
 
@@ -214,42 +211,37 @@ fn create_root_device() -> Result<()> {
     let mut hardware_id = wide(ROOT_HARDWARE_ID);
     hardware_id.push(0); // the property is a list of strings
 
-    // SAFETY: the information list is destroyed on every path, and the
-    // property buffer is described with its real length in bytes.
+    // SAFETY: the property buffer is described with its real length in bytes,
+    // and the set is destroyed wherever this scope ends.
     unsafe {
-        let set = SetupDiCreateDeviceInfoList(Some(&SYSTEM_DEVICE_CLASS), None)
-            .map_err(|error| Error::Install(format!("device list: {error}")))?;
+        let set = DeviceInfoSet::new(
+            SetupDiCreateDeviceInfoList(Some(&SYSTEM_DEVICE_CLASS), None)
+                .map_err(|error| Error::Install(format!("device list: {error}")))?,
+        );
 
-        let result = (|| -> Result<()> {
-            let mut info = SP_DEVINFO_DATA {
-                cbSize: std::mem::size_of::<SP_DEVINFO_DATA>() as u32,
-                ..Default::default()
-            };
+        let mut info = SP_DEVINFO_DATA {
+            cbSize: std::mem::size_of::<SP_DEVINFO_DATA>() as u32,
+            ..Default::default()
+        };
 
-            SetupDiCreateDeviceInfoW(
-                set,
-                PCWSTR(name.as_ptr()),
-                &SYSTEM_DEVICE_CLASS,
-                PCWSTR::null(),
-                None,
-                DICD_GENERATE_ID,
-                Some(&mut info),
-            )
-            .map_err(|error| Error::Install(format!("device node: {error}")))?;
+        SetupDiCreateDeviceInfoW(
+            set.handle(),
+            PCWSTR(name.as_ptr()),
+            &SYSTEM_DEVICE_CLASS,
+            PCWSTR::null(),
+            None,
+            DICD_GENERATE_ID,
+            Some(&mut info),
+        )
+        .map_err(|error| Error::Install(format!("device node: {error}")))?;
 
-            let bytes = std::slice::from_raw_parts(
-                hardware_id.as_ptr().cast::<u8>(),
-                hardware_id.len() * 2,
-            );
-            SetupDiSetDeviceRegistryPropertyW(set, &mut info, SPDRP_HARDWAREID, Some(bytes))
-                .map_err(|error| Error::Install(format!("hardware id: {error}")))?;
+        let bytes =
+            std::slice::from_raw_parts(hardware_id.as_ptr().cast::<u8>(), hardware_id.len() * 2);
+        SetupDiSetDeviceRegistryPropertyW(set.handle(), &mut info, SPDRP_HARDWAREID, Some(bytes))
+            .map_err(|error| Error::Install(format!("hardware id: {error}")))?;
 
-            SetupDiCallClassInstaller(DIF_REGISTERDEVICE, set, Some(&info))
-                .map_err(|error| Error::Install(format!("device registration: {error}")))
-        })();
-
-        let _ = SetupDiDestroyDeviceInfoList(set);
-        result
+        SetupDiCallClassInstaller(DIF_REGISTERDEVICE, set.handle(), Some(&info))
+            .map_err(|error| Error::Install(format!("device registration: {error}")))
     }
 }
 
@@ -288,13 +280,16 @@ fn visit_leftover_devices(action: Leftovers) -> i32 {
         Leftovers::Remove => DIGCF_ALLCLASSES,
     };
 
-    // SAFETY: the set is destroyed before returning and every device handed to
-    // SetupDiRemoveDevice came out of the same enumeration.
+    // Named rather than passed inline: the pointer must outlive the call.
+    let filter = wide("LGHUBDEVICE");
+
+    // SAFETY: every device handed to SetupDiRemoveDevice came out of the same
+    // enumeration, which outlives the loop.
     unsafe {
-        let Ok(set) = SetupDiGetClassDevsW(None, PCWSTR(wide("LGHUBDEVICE").as_ptr()), None, scope)
-        else {
+        let Ok(set) = SetupDiGetClassDevsW(None, PCWSTR(filter.as_ptr()), None, scope) else {
             return 0;
         };
+        let set = DeviceInfoSet::new(set);
 
         let mut index = 0;
         loop {
@@ -302,7 +297,7 @@ fn visit_leftover_devices(action: Leftovers) -> i32 {
                 cbSize: std::mem::size_of::<SP_DEVINFO_DATA>() as u32,
                 ..Default::default()
             };
-            if SetupDiEnumDeviceInfo(set, index, &mut info).is_err() {
+            if SetupDiEnumDeviceInfo(set.handle(), index, &mut info).is_err() {
                 break;
             }
             index += 1;
@@ -310,14 +305,12 @@ fn visit_leftover_devices(action: Leftovers) -> i32 {
             match action {
                 Leftovers::Count => found += 1,
                 Leftovers::Remove => {
-                    if SetupDiRemoveDevice(set, &mut info).as_bool() {
+                    if SetupDiRemoveDevice(set.handle(), &mut info).as_bool() {
                         found += 1;
                     }
                 }
             }
         }
-
-        let _ = SetupDiDestroyDeviceInfoList(set);
     }
 
     found
@@ -339,8 +332,7 @@ pub fn uninstall() -> Result<()> {
 
         // A removal that only finishes after a restart still counts as done:
         // the copy left behind is the one the kernel already has open, which is
-        // exactly what removing a loaded driver looks like. Treating it as a
-        // failure reported every ordinary removal as broken.
+        // exactly what removing a loaded driver looks like.
         let code = output.status.code().unwrap_or(-1);
         if code != 0 && code != RESTART_TO_FINISH {
             return Err(Error::Uninstall(format!(
@@ -360,7 +352,7 @@ fn blamed() -> String {
 }
 
 /// The wording, kept apart from the asking so it can be tested without a driver
-/// on the machine. A failure with nobody to blame says nothing extra.
+/// on the machine.
 fn blame(holders: &[String]) -> String {
     if holders.is_empty() {
         String::new()
@@ -460,8 +452,8 @@ struct Package {
 }
 
 impl Package {
-    /// The file name is compared without regard to case: Windows file names are
-    /// case insensitive, and mistaking our own package for someone else's would
+    /// Compared without regard to case: Windows file names are case
+    /// insensitive, and mistaking our own package for someone else's would
     /// leave the user unable to remove the driver at all.
     fn is_ours(&self) -> bool {
         [BUS_PACKAGE, HID_PACKAGE]
@@ -476,8 +468,8 @@ impl Package {
 ///
 /// The labels are deliberately ignored: Windows translates them, and a parser
 /// that matched them would report an empty driver store on a Russian or
-/// Ukrainian machine. The order of the fields and the values themselves read
-/// the same in every language.
+/// Ukrainian machine. The order of the fields and the values read the same in
+/// every language.
 ///
 /// A record therefore starts at the first value that names an .inf file, which
 /// is what separates the records from the heading printed above them.
@@ -529,7 +521,7 @@ fn find_devices(hardware_id: &str) -> Vec<String> {
     let mut found = Vec::new();
     let filter = wide(hardware_id);
 
-    // SAFETY: the set is destroyed before returning; the buffer is sized by us.
+    // SAFETY: the buffer is sized by us and the set outlives the loop.
     unsafe {
         let Ok(set) = SetupDiGetClassDevsW(
             Some(&SYSTEM_DEVICE_CLASS),
@@ -539,6 +531,7 @@ fn find_devices(hardware_id: &str) -> Vec<String> {
         ) else {
             return found;
         };
+        let set = DeviceInfoSet::new(set);
 
         let mut index = 0;
         loop {
@@ -546,20 +539,18 @@ fn find_devices(hardware_id: &str) -> Vec<String> {
                 cbSize: std::mem::size_of::<SP_DEVINFO_DATA>() as u32,
                 ..Default::default()
             };
-            if SetupDiEnumDeviceInfo(set, index, &mut info).is_err() {
+            if SetupDiEnumDeviceInfo(set.handle(), index, &mut info).is_err() {
                 break;
             }
             index += 1;
 
             let mut buffer = [0u16; 512];
-            if SetupDiGetDeviceInstanceIdW(set, &info, Some(&mut buffer), None).is_ok() {
+            if SetupDiGetDeviceInstanceIdW(set.handle(), &info, Some(&mut buffer), None).is_ok() {
                 if let Ok(id) = PCWSTR(buffer.as_ptr()).to_string() {
                     found.push(id);
                 }
             }
         }
-
-        let _ = SetupDiDestroyDeviceInfoList(HDEVINFO(set.0));
     }
 
     found
@@ -691,6 +682,13 @@ mod tests {
     #[test]
     fn counting_the_leftover_devices_leaves_them_where_they_are() {
         assert_eq!(leftover_devices(), leftover_devices());
+    }
+
+    /// Looking for a hardware id nothing answers to must end quietly and give
+    /// the set it opened back.
+    #[test]
+    fn a_hardware_id_nothing_answers_to_finds_no_devices() {
+        assert!(find_devices(r"root\NoSuchDeviceOfOurs").is_empty());
     }
 
     /// Windows did the work there and then, so there is nothing to read.

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -23,6 +23,7 @@ pub use reboot::{
 use std::borrow::Cow;
 use std::ffi::OsString;
 use std::fmt;
+use std::os::windows::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Mutex, MutexGuard, PoisonError, TryLockError};
@@ -35,10 +36,8 @@ use crate::hid::{KeyboardReport, MouseReport};
 use device::{Devices, VirtualDeviceId};
 
 /// How long the bus is given to finish taking the child devices away, and how
-/// often to look.
-///
-/// A wait for something that can be seen, rather than a pause in the hope that
-/// it happened: a pause is a guess about a machine we are not running on.
+/// often to look. A wait for something that can be seen, rather than a pause in
+/// the hope that it happened.
 const REMOVAL_TIMEOUT: Duration = Duration::from_secs(3);
 const REMOVAL_POLL: Duration = Duration::from_millis(50);
 
@@ -251,7 +250,6 @@ impl Driver {
     ///
     /// The connection goes through the same root device, so it is closed and
     /// opened again: the old handle does not survive the stack being rebuilt.
-    /// Meanwhile a report is turned down and the real key goes through instead.
     fn rebuild_bus(&self) -> Result<()> {
         self.connection().close();
 
@@ -606,12 +604,25 @@ pub(crate) fn wide(value: &str) -> Vec<u16> {
     value.encode_utf16().chain(std::iter::once(0)).collect()
 }
 
+/// The same, for a path.
+///
+/// A path is not a `String`: Windows stores it as UTF-16 that need not be well
+/// formed, and going through `Display` turns whatever will not convert into
+/// replacement characters - a path to a folder that does not exist. Encoding
+/// the `OsStr` directly hands Windows back the units it gave us.
+#[allow(dead_code)] // used by the installer
+pub(crate) fn wide_path(path: &Path) -> Vec<u16> {
+    path.as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect()
+}
+
 /// An absolute path to one of the programs shipped with Windows.
 ///
 /// This process is always elevated, so a helper must never be named by its bare
 /// file name: that resolves through PATH, and a writable directory ahead of
-/// System32 would decide what an administrator runs. Neither of the two
-/// programs used here is ever anything but the system one.
+/// System32 would decide what an administrator runs.
 pub(crate) fn system32(program: &str) -> PathBuf {
     let root = std::env::var_os("SystemRoot").unwrap_or_else(|| OsString::from(r"C:\Windows"));
 
@@ -638,6 +649,29 @@ mod tests {
     fn wide_strings_are_null_terminated() {
         assert_eq!(wide("ab"), vec![0x61, 0x62, 0x00]);
         assert_eq!(wide(""), vec![0x00]);
+    }
+
+    #[test]
+    fn a_path_is_encoded_the_way_windows_stores_it() {
+        let path = Path::new(r"C:\Windows\System32");
+
+        assert_eq!(wide_path(path), wide(r"C:\Windows\System32"));
+        assert_eq!(wide_path(Path::new("")), vec![0x00]);
+    }
+
+    /// The units of a path that is not valid Unicode have to survive; going
+    /// through a String would replace them.
+    #[test]
+    fn a_path_that_is_not_valid_unicode_keeps_its_units() {
+        use std::os::windows::ffi::OsStringExt;
+
+        // A lone high surrogate: a well formed UTF-16 path Windows accepts and
+        // Rust will not turn into a str.
+        let units = [0x0043, 0x003A, 0x005C, 0xD800, 0x0000];
+        let path = PathBuf::from(OsString::from_wide(&units[..units.len() - 1]));
+
+        assert_eq!(wide_path(&path), units);
+        assert!(path.to_string_lossy().contains('\u{FFFD}'));
     }
 
     /// A bare file name would be resolved through PATH by an elevated process.

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -610,7 +610,6 @@ pub(crate) fn wide(value: &str) -> Vec<u16> {
 /// formed, and going through `Display` turns whatever will not convert into
 /// replacement characters - a path to a folder that does not exist. Encoding
 /// the `OsStr` directly hands Windows back the units it gave us.
-#[allow(dead_code)] // used by the installer
 pub(crate) fn wide_path(path: &Path) -> Vec<u16> {
     path.as_os_str()
         .encode_wide()
@@ -665,8 +664,8 @@ mod tests {
     fn a_path_that_is_not_valid_unicode_keeps_its_units() {
         use std::os::windows::ffi::OsStringExt;
 
-        // A lone high surrogate: a well formed UTF-16 path Windows accepts and
-        // Rust will not turn into a str.
+        // A lone high surrogate: a path Windows accepts and Rust will not turn
+        // into a str.
         let units = [0x0043, 0x003A, 0x005C, 0xD800, 0x0000];
         let path = PathBuf::from(OsString::from_wide(&units[..units.len() - 1]));
 
@@ -729,13 +728,14 @@ mod tests {
         assert_eq!(attempts, PLUG_ATTEMPTS);
     }
 
-    /// On a machine with no virtual device of ours there is nothing to wait
-    /// for, and the wait has to notice that instead of sitting out its timeout.
+    /// The wait has to answer, not sit out its timeout. Whether the bus is
+    /// empty depends on the machine - our own program may be running in another
+    /// window - so only the promptness is asserted.
     #[test]
     fn an_empty_bus_is_noticed_without_waiting() {
         let started = Instant::now();
+        let _ = wait_for_empty_bus();
 
-        assert!(wait_for_empty_bus());
         assert!(started.elapsed() < REMOVAL_TIMEOUT);
     }
 

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -21,7 +21,9 @@ pub use reboot::{
 };
 
 use std::borrow::Cow;
+use std::ffi::OsString;
 use std::fmt;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Mutex, MutexGuard, PoisonError, TryLockError};
 use std::thread::sleep;
@@ -35,16 +37,13 @@ use device::{Devices, VirtualDeviceId};
 /// How long the bus is given to finish taking the child devices away, and how
 /// often to look.
 ///
-/// This is a wait for something that can be seen - the devices disappearing
-/// from the bus - rather than a pause in the hope that it happened. A pause is
-/// a guess about a machine we are not running on, and the request that follows
-/// it is refused with an invalid parameter that explains nothing.
+/// A wait for something that can be seen, rather than a pause in the hope that
+/// it happened: a pause is a guess about a machine we are not running on.
 const REMOVAL_TIMEOUT: Duration = Duration::from_secs(3);
 const REMOVAL_POLL: Duration = Duration::from_millis(50);
 
 /// How long the driver is given to publish its device again after the bus has
-/// been rebuilt. Plug and play has to build the whole stack anew, which takes
-/// noticeably longer than a removal.
+/// been rebuilt. Building the whole stack anew takes longer than a removal.
 const REOPEN_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// How many times a refused plug is worth repeating, and how long to wait in
@@ -59,8 +58,8 @@ pub enum Step {
     PreparingFiles,
     ClosingLogitechSoftware,
     InstallingDriver,
-    /// Carries both builds, because replacing a driver behind someone's back is
-    /// exactly the kind of thing they are entitled to read the details of.
+    /// Carries both builds: replacing someone's driver is worth reading the
+    /// details of.
     ReplacingDriver(version::Mismatch),
     DriverReady,
     CleaningPreviousSession,
@@ -134,13 +133,11 @@ pub struct Driver {
     /// the bus tears down the very device this connection goes through.
     devices: Mutex<Devices>,
     plugged: Mutex<PluggedDevices>,
-    // Kept alive on purpose: the extracted files are removed when this is
-    // dropped, and the installer may still want to read them - both on the way
-    // up and every time the bus is rebuilt.
+    /// Kept alive on purpose: dropping it removes the extracted files, which
+    /// the installer still reads every time the bus is rebuilt.
     payload: ExtractedDrivers,
-    // Also kept alive on purpose, and never read: it keeps G HUB closed for as
-    // long as this connection exists, and stops the moment it is dropped, so
-    // nothing of ours outlives the session.
+    /// Kept alive on purpose and never read: it keeps G HUB closed for as long
+    /// as this connection exists.
     _watchdog: ghub::Watchdog,
 }
 
@@ -155,13 +152,9 @@ impl Driver {
         report.step(Step::PreparingFiles);
         let payload = ExtractedDrivers::unpack()?;
 
-        // Before the driver is touched at all: G HUB plugs its own virtual
-        // keyboard and mouse with the very product ids we ask for, and a
-        // product id can only be taken once. Its agent starts itself again a
-        // moment after it is closed, so the watchdog keeps looking for as long
-        // as this connection lives. Nothing of the user's is lost - profiles,
-        // macros and lighting live in the application's own files, and are
-        // applied again the next time it runs.
+        // G HUB takes the very product ids we ask for, and a product id can
+        // only be taken once. Its agent starts itself again a moment after it
+        // is closed, so the watchdog keeps looking for as long as we run.
         if ghub::is_running() {
             report.step(Step::ClosingLogitechSoftware);
             ghub::stop();
@@ -169,23 +162,18 @@ impl Driver {
         let watchdog = ghub::Watchdog::start();
 
         if service::driver_installed() {
-            // A build we did not read the protocol out of answers our requests
-            // with an invalid parameter and no reason, which is the same thing
-            // it says when a device is merely busy - so it is not something to
-            // find out about later, from a failure that names nothing. Ours
-            // goes in whichever way the versions differ: a protocol is not a
-            // version number to be compared for greatness.
+            // A build we did not read the protocol out of answers with an
+            // invalid parameter and no reason - the same thing it says when a
+            // device is merely busy. A protocol is not a version number to be
+            // compared for greatness, so ours goes in whichever way they differ.
             match version::mismatch(payload.directory()) {
                 None => {
                     report.step(Step::DriverReady);
 
-                    // Re-binding the bus driver on every start is not optional:
-                    // without it the first plug after a service restart fails
-                    // with an invalid parameter, because the bus keeps stale
-                    // state from the last session. A fresh install does this on
-                    // its way through, so it is only needed on the path that
-                    // skips the installer - binding twice costs a second or two
-                    // of plug and play for nothing.
+                    // Re-binding on every start is not optional: without it the
+                    // first plug after a service restart fails with an invalid
+                    // parameter, because the bus keeps stale state. A fresh
+                    // install does this on its way through.
                     install::bind_root_device(payload.directory())?;
                 }
                 Some(mismatch) => {
@@ -202,9 +190,8 @@ impl Driver {
 
         service::start_all();
 
-        // The driver is present and answering, so a restart owed by an earlier
-        // removal either happened or no longer applies. The flag must not
-        // outlive the condition it describes.
+        // The driver is answering, so a restart owed by an earlier removal no
+        // longer applies. The flag must not outlive the condition it describes.
         reboot::clear_restart_pending();
 
         if install::remove_leftover_devices() > 0 {
@@ -231,23 +218,20 @@ impl Driver {
 
     /// Unplugs the virtual keyboard and mouse and creates them again.
     ///
-    /// This takes `&self` because the redirect engine holds the driver through
-    /// an `Arc`: everything that changes here sits behind its own lock.
+    /// Takes `&self` because the redirect engine holds the driver through an
+    /// `Arc`: everything that changes here sits behind its own lock.
     pub fn recreate_virtual_devices(&self, report: &mut dyn Report) -> Result<()> {
         let refused = self.unplug_virtual_devices();
 
-        // The clean case: the driver let both devices go and Windows took them
-        // off the bus, so the next pair can be created straight away.
+        // The clean case: both devices went and Windows took them off the bus.
         if refused.is_empty() && wait_for_empty_bus() {
             return self.create_virtual_devices(report);
         }
 
         // A refusal means the driver still believes one of the children exists.
-        // Taking the device node away with the setup API does not change its
-        // mind - the bus reports the same child again on its next enumeration -
-        // and the product id stays taken, which is what the next plug is
-        // refused for. Only handing the bus driver back to plug and play clears
-        // it, and that is exactly what a restart of this program does.
+        // Taking the device node away does not change its mind - the bus
+        // reports the same child again - and the product id stays taken. Only
+        // handing the bus driver back to plug and play clears it.
         report.step(Step::RebuildingBus);
         install::remove_leftover_devices();
         self.rebuild_bus()?;
@@ -265,11 +249,9 @@ impl Driver {
     /// Hands the bus driver back to plug and play so that it forgets the
     /// children it still thinks it has.
     ///
-    /// The connection goes through the same root device, so it is closed first
-    /// and opened again afterwards: plug and play builds the stack anew and the
-    /// handle from before does not survive that. While it is closed, a report
-    /// on its way to the driver is turned down and the real key or button goes
-    /// through instead, which is the right answer for those few seconds.
+    /// The connection goes through the same root device, so it is closed and
+    /// opened again: the old handle does not survive the stack being rebuilt.
+    /// Meanwhile a report is turned down and the real key goes through instead.
     fn rebuild_bus(&self) -> Result<()> {
         self.connection().close();
 
@@ -322,12 +304,10 @@ impl Driver {
     /// Creates one device, unless the program is on its way out.
     ///
     /// Closing the window runs the cleanup on a thread Windows injects, and it
-    /// can arrive while this one is waiting for the bus - creating a pair takes
-    /// the better part of a second. The cleanup only knows about the devices
-    /// that were on the list when it looked, so one finished afterwards would
-    /// be left behind on the bus, showing up in Device Manager as a Logitech
-    /// device that is not there. Asking twice - before starting and again once
-    /// the bus answers - is what keeps that window down to a single request.
+    /// can arrive while this one is waiting for the bus. The cleanup only knows
+    /// about the devices that were on the list when it looked, so one finished
+    /// afterwards would be left on the bus. Asking twice - before starting and
+    /// again once the bus answers - keeps that window down to a single request.
     fn plug_unless_leaving(
         &self,
         plug: impl Fn(&Devices) -> Result<VirtualDeviceId>,
@@ -349,16 +329,12 @@ impl Driver {
     /// Asks the driver to take both virtual devices away, and names the ones it
     /// would not.
     ///
-    /// The refusals used to be discarded, and that is how a device could stay
-    /// on the bus while the program believed it had gone: the plug that came
-    /// next asked for a product id that was still taken, and was turned down
-    /// with an invalid parameter that named no reason. The names are what tell
-    /// the caller to stop believing, and what the user is shown when nothing
-    /// helps.
+    /// A discarded refusal is how a device could stay on the bus while the
+    /// program believed it had gone: the next plug asked for a product id that
+    /// was still taken and was turned down with an invalid parameter.
     ///
     /// The lock over the ids is let go of before the driver is spoken to: they
-    /// are ours the moment they are taken out, and a kernel call is not worth
-    /// holding a lock across.
+    /// are ours the moment they are taken out.
     fn unplug_virtual_devices(&self) -> Refused {
         let devices: Vec<(&'static str, VirtualDeviceId)> = {
             let mut plugged = self.plugged_devices();
@@ -380,9 +356,8 @@ impl Driver {
         Refused { names }
     }
 
-    /// A poisoned lock only means that some thread panicked while holding it.
-    /// What is behind it is still what the driver handed us, so it is taken as
-    /// it is rather than turning a panic into a second one.
+    /// A poisoned lock only means some thread panicked while holding it. What
+    /// is behind it is still what the driver handed us.
     fn plugged_devices(&self) -> MutexGuard<'_, PluggedDevices> {
         self.plugged.lock().unwrap_or_else(PoisonError::into_inner)
     }
@@ -396,10 +371,8 @@ impl Driver {
     /// The connection, or an error when it is busy being replaced.
     ///
     /// The hooks reach the driver from inside a low-level hook callback, where
-    /// waiting is not free: Windows quietly drops a hook that takes too long,
-    /// and the redirect then stops working with nothing to show for it. A
-    /// report lost while the bus is being rebuilt is the cheaper outcome - the
-    /// key or the button simply goes through as the real device's.
+    /// Windows quietly drops a hook that takes too long. A report lost while
+    /// the bus is being rebuilt is the cheaper outcome.
     fn connection_now(&self) -> Result<MutexGuard<'_, Devices>> {
         match self.devices.try_lock() {
             Ok(devices) => Ok(devices),
@@ -426,12 +399,9 @@ impl Driver {
 
     /// Lets go of every key, waiting for the connection if it is busy.
     ///
-    /// Only for callers that are not a hook callback. [`Self::send_keyboard`]
-    /// gives up rather than wait, which is right for a hook - a lost keystroke
-    /// costs less than a stalled desktop - but wrong for switching the redirect
-    /// off, where the whole point of the report is that nothing stays held.
-    /// Nothing sends another one afterwards, so losing this one leaves a key
-    /// down for the rest of the session.
+    /// Not for a hook callback. [`Self::send_keyboard`] gives up rather than
+    /// wait, which is right for a hook but wrong here: nothing sends another
+    /// report afterwards, so losing this one leaves a key down for the session.
     pub fn release_keyboard_waiting(&self) -> Result<()> {
         self.connection().send_keyboard(KeyboardReport::EMPTY)
     }
@@ -444,17 +414,15 @@ impl Driver {
     /// Leaves the machine as if this program had never run: nothing held down
     /// and no virtual device on the bus.
     ///
-    /// Calling this twice is harmless, which matters because the ways out of
-    /// the program overlap - a menu choice, a closed window and a dropped
-    /// owner can all arrive at it.
+    /// Calling this twice is harmless, which matters because a menu choice, a
+    /// closed window and a dropped owner can all arrive at it.
     pub fn park(&self) {
         self.release_everything();
 
-        // A device the driver would not let go of stays on the bus and shows up
-        // in Device Manager as a Logitech mouse that is not there. Taking the
-        // node off is the most that can be done on the way out: rebuilding the
-        // bus takes seconds, and this also runs while the window is closing,
-        // where there are none to spare. The next start rebuilds it anyway.
+        // A device the driver would not let go of shows up in Device Manager as
+        // a Logitech mouse that is not there. Taking the node off is the most
+        // that can be done on the way out: rebuilding the bus takes seconds,
+        // and this also runs while the window is closing.
         if !self.unplug_virtual_devices().is_empty() {
             install::remove_leftover_devices();
         }
@@ -465,8 +433,8 @@ impl Driver {
         let plugged = self.plugged_devices();
 
         Status {
-            // A connection that is busy being replaced is not one to report as
-            // ready, and the status line must never be what waits for it.
+            // A connection busy being replaced is not one to report as ready,
+            // and the status line must never be what waits for it.
             connected: self.connection_now().is_ok_and(|devices| devices.is_open()),
             virtual_keyboard: plugged.keyboard.is_some(),
             virtual_mouse: plugged.mouse.is_some(),
@@ -486,8 +454,7 @@ impl Driver {
 
 impl Drop for Driver {
     fn drop(&mut self) {
-        // Whatever happened - a clean exit, a closed console window, a panic -
-        // no key may stay held down after we are gone.
+        // A clean exit, a closed console window and a panic all end up here.
         self.park();
     }
 }
@@ -516,9 +483,8 @@ impl fmt::Display for Refused {
 
 /// Waits until no virtual device of an earlier session is left on the bus.
 ///
-/// Answers `false` when the timeout runs out with something still there, which
-/// is worth knowing rather than pressing on: the device that is still present
-/// holds the product id the next one is about to ask for.
+/// `false` means the timeout ran out with something still there, which is worth
+/// knowing: it holds the product id the next device is about to ask for.
 fn wait_for_empty_bus() -> bool {
     let deadline = Instant::now() + REMOVAL_TIMEOUT;
 
@@ -536,11 +502,9 @@ fn wait_for_empty_bus() -> bool {
 
 /// Opens the driver, giving plug and play time to publish its device.
 ///
-/// The already-installed path re-binds the bus on every start, which restarts
-/// the core child underneath it, and the first open can arrive before the
-/// interface is back. A single attempt then fails a start that a moment's wait
-/// would have carried, so the open is retried until the driver answers or the
-/// deadline runs out - the same wait a rebuilt bus is already given.
+/// Re-binding the bus restarts the core child underneath it, so the first open
+/// can arrive before the interface is back. A single attempt would fail a start
+/// that a moment's wait would have carried.
 fn open_within_timeout() -> Result<Devices> {
     let deadline = Instant::now() + REOPEN_TIMEOUT;
 
@@ -556,8 +520,7 @@ fn open_within_timeout() -> Result<Devices> {
 /// Repeats a plug that was turned down, pausing in between.
 ///
 /// The bus answers a request that arrives too early with the same refusal it
-/// uses for a malformed one, so there is nothing to tell the two apart by:
-/// asking again a few times is what separates "too early" from "wrong".
+/// uses for a malformed one, so asking again is what separates the two.
 fn keep_trying<T>(mut plug: impl FnMut() -> Result<T>) -> Result<T> {
     let mut attempt = 1;
 
@@ -575,14 +538,11 @@ fn keep_trying<T>(mut plug: impl FnMut() -> Result<T>) -> Result<T> {
 
 /// Whether the program has begun leaving, from wherever it was asked to.
 ///
-/// The window can be closed at any moment, and Windows then gives the process a
-/// few seconds on a thread of its own before taking it away. Anything that
-/// creates a device has to know, because a device created after the cleanup has
-/// looked at the list is one nothing will take away.
+/// Anything that creates a device has to know: one created after the cleanup
+/// has looked at the list is one nothing will take away.
 static SHUTTING_DOWN: AtomicBool = AtomicBool::new(false);
 
-/// Says that the program is on its way out. Nothing turns this back off: there
-/// is no way back from it.
+/// Says that the program is on its way out. There is no way back from it.
 pub fn begin_shutdown() {
     SHUTTING_DOWN.store(true, Ordering::SeqCst);
 }
@@ -597,9 +557,6 @@ fn leaving() -> Error {
 }
 
 /// True when the driver package is installed and its services are running.
-///
-/// This is the one state in which a restart owed by an earlier removal cannot
-/// still be pending: the driver is plainly here and answering.
 #[must_use]
 pub fn is_running() -> bool {
     service::driver_running()
@@ -607,8 +564,8 @@ pub fn is_running() -> bool {
 
 /// True when the program runs with administrator rights.
 ///
-/// The token knows this itself, which is both shorter and steadier than
-/// assembling the administrators SID and asking whether we are a member of it.
+/// The token knows this itself, which is steadier than assembling the
+/// administrators SID and asking whether we are a member of it.
 #[must_use]
 pub fn is_elevated() -> bool {
     use std::mem::size_of;
@@ -649,6 +606,18 @@ pub(crate) fn wide(value: &str) -> Vec<u16> {
     value.encode_utf16().chain(std::iter::once(0)).collect()
 }
 
+/// An absolute path to one of the programs shipped with Windows.
+///
+/// This process is always elevated, so a helper must never be named by its bare
+/// file name: that resolves through PATH, and a writable directory ahead of
+/// System32 would decide what an administrator runs. Neither of the two
+/// programs used here is ever anything but the system one.
+pub(crate) fn system32(program: &str) -> PathBuf {
+    let root = std::env::var_os("SystemRoot").unwrap_or_else(|| OsString::from(r"C:\Windows"));
+
+    Path::new(&root).join("System32").join(program)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -669,6 +638,19 @@ mod tests {
     fn wide_strings_are_null_terminated() {
         assert_eq!(wide("ab"), vec![0x61, 0x62, 0x00]);
         assert_eq!(wide(""), vec![0x00]);
+    }
+
+    /// A bare file name would be resolved through PATH by an elevated process.
+    #[test]
+    fn a_system_program_is_named_by_an_absolute_path() {
+        let path = system32("pnputil.exe");
+
+        assert!(path.is_absolute(), "{path:?} would be resolved through PATH");
+        assert!(path.ends_with("pnputil.exe"));
+        assert!(path
+            .to_string_lossy()
+            .to_lowercase()
+            .contains(r"system32\pnputil.exe"));
     }
 
     #[test]
@@ -714,8 +696,7 @@ mod tests {
     }
 
     /// On a machine with no virtual device of ours there is nothing to wait
-    /// for, and the wait has to notice that at once instead of sitting out its
-    /// timeout - which is what a fixed pause did.
+    /// for, and the wait has to notice that instead of sitting out its timeout.
     #[test]
     fn an_empty_bus_is_noticed_without_waiting() {
         let started = Instant::now();
@@ -724,8 +705,7 @@ mod tests {
         assert!(started.elapsed() < REMOVAL_TIMEOUT);
     }
 
-    /// The message the user is left with when nothing worked has to read as a
-    /// sentence, whichever device was the one that would not go.
+    /// The message shown when nothing worked has to read as a sentence.
     #[test]
     fn the_refused_devices_are_named_the_way_a_user_would_name_them() {
         assert_eq!(
@@ -745,9 +725,8 @@ mod tests {
         assert!(Refused { names: vec![] }.is_empty());
     }
 
-    /// Replacing someone's driver is the one step they are most likely to want
-    /// to ask about afterwards, so it has to say which build went and which
-    /// came - in the form they would quote it in.
+    /// Replacing a driver is the step a user is most likely to ask about, so it
+    /// has to say which build went and which came.
     #[test]
     fn the_step_that_replaces_the_driver_names_both_builds() {
         let text = Step::ReplacingDriver(mismatch()).to_string();

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -678,7 +678,10 @@ mod tests {
     fn a_system_program_is_named_by_an_absolute_path() {
         let path = system32("pnputil.exe");
 
-        assert!(path.is_absolute(), "{path:?} would be resolved through PATH");
+        assert!(
+            path.is_absolute(),
+            "{path:?} would be resolved through PATH"
+        );
         assert!(path.ends_with("pnputil.exe"));
         assert!(path
             .to_string_lossy()

--- a/src/driver/process.rs
+++ b/src/driver/process.rs
@@ -16,6 +16,27 @@ use windows::Win32::System::Threading::{
 /// Long enough for any path Windows will hand back, including the long ones.
 const LONGEST_PATH: usize = 1024;
 
+/// A handle that is closed when it goes out of scope.
+///
+/// Used for both the process listing and the processes it names, so no path
+/// out of the functions below can leave a kernel handle behind.
+struct OwnedHandle(HANDLE);
+
+impl OwnedHandle {
+    fn get(&self) -> HANDLE {
+        self.0
+    }
+}
+
+impl Drop for OwnedHandle {
+    fn drop(&mut self) {
+        // SAFETY: the handle came from Windows and is closed exactly once.
+        unsafe {
+            let _ = CloseHandle(self.0);
+        }
+    }
+}
+
 /// The ids of the running processes whose file name `wanted` accepts.
 ///
 /// Looking changes nothing, which is worth saying because the caller usually
@@ -23,28 +44,27 @@ const LONGEST_PATH: usize = 1024;
 pub fn ids_of(wanted: impl Fn(&str) -> bool) -> Vec<u32> {
     let mut found = Vec::new();
 
-    // SAFETY: the snapshot is closed on every path out of here, and the entry
-    // is given its real size before Windows is asked to fill it in.
+    // SAFETY: the entry is given its real size before Windows is asked to fill
+    // it in, and the snapshot outlives every call that reads from it.
     unsafe {
         let Ok(snapshot) = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0) else {
             return found;
         };
+        let snapshot = OwnedHandle(snapshot);
 
         let mut entry = PROCESSENTRY32W {
             dwSize: std::mem::size_of::<PROCESSENTRY32W>() as u32,
             ..Default::default()
         };
 
-        let mut listed = Process32FirstW(snapshot, &mut entry).is_ok();
+        let mut listed = Process32FirstW(snapshot.get(), &mut entry).is_ok();
         while listed {
             if wanted(&name_of(&entry)) {
                 found.push(entry.th32ProcessID);
             }
 
-            listed = Process32NextW(snapshot, &mut entry).is_ok();
+            listed = Process32NextW(snapshot.get(), &mut entry).is_ok();
         }
-
-        let _ = CloseHandle(snapshot);
     }
 
     found
@@ -66,21 +86,25 @@ pub fn ids_of(wanted: impl Fn(&str) -> bool) -> Vec<u32> {
 /// A process that has already gone, or one we are not allowed to close, is not
 /// reported: either way it is not in the way any more.
 pub fn terminate(process: u32, wanted: impl Fn(&str) -> bool) {
-    // SAFETY: the handle is closed on every path that opened it.
-    unsafe {
-        let Ok(handle) = OpenProcess(
+    // SAFETY: the handle is owned by the guard below and closed with it.
+    let opened = unsafe {
+        OpenProcess(
             PROCESS_TERMINATE | PROCESS_QUERY_LIMITED_INFORMATION,
             false,
             process,
-        ) else {
-            return;
-        };
+        )
+    };
 
-        if image_name(handle).is_some_and(|name| wanted(&name)) {
-            let _ = TerminateProcess(handle, 0);
+    let Ok(handle) = opened else {
+        return;
+    };
+    let handle = OwnedHandle(handle);
+
+    if image_name(handle.get()).is_some_and(|name| wanted(&name)) {
+        // SAFETY: the handle names the process whose image was just read.
+        unsafe {
+            let _ = TerminateProcess(handle.get(), 0);
         }
-
-        let _ = CloseHandle(handle);
     }
 }
 
@@ -149,6 +173,14 @@ mod tests {
         assert!(!ids_of(|name| name.eq_ignore_ascii_case(&ours())).is_empty());
     }
 
+    /// Listing repeatedly must not run the process out of handles.
+    #[test]
+    fn listing_over_and_over_leaves_nothing_open() {
+        for _ in 0..64 {
+            assert!(!ids_of(|name| name.eq_ignore_ascii_case(&ours())).is_empty());
+        }
+    }
+
     /// The process this test runs in is the one case where the outcome of a
     /// refused termination can be observed: reaching the next line is it.
     #[test]
@@ -170,8 +202,7 @@ mod tests {
     #[test]
     fn the_name_read_from_a_handle_is_the_one_the_listing_reports() {
         // SAFETY: a pseudo handle to this process; nothing is opened or closed.
-        let ourselves =
-            unsafe { windows::Win32::System::Threading::GetCurrentProcess() };
+        let ourselves = unsafe { windows::Win32::System::Threading::GetCurrentProcess() };
 
         assert_eq!(
             image_name(ourselves).map(|name| name.to_lowercase()),

--- a/src/driver/process.rs
+++ b/src/driver/process.rs
@@ -1,9 +1,7 @@
 //! The two things this program needs to know about other processes: which of
 //! them are running, and how to close one.
 //!
-//! Neither is a policy. Whose processes are worth closing, and why, is decided
-//! by the modules that ask - G HUB has to let go of the virtual devices, and
-//! the plug and play utility has to be closed when it stops answering at all.
+//! Whose processes are worth closing is decided by the modules that ask.
 
 use windows::Win32::Foundation::CloseHandle;
 use windows::Win32::System::Diagnostics::ToolHelp::{
@@ -19,8 +17,7 @@ pub fn ids_of(wanted: impl Fn(&str) -> bool) -> Vec<u32> {
     let mut found = Vec::new();
 
     // SAFETY: the snapshot is closed on every path out of here, and the entry
-    // is given its real size before Windows is asked to fill it in - a call
-    // that would fail outright without it.
+    // is given its real size before Windows is asked to fill it in.
     unsafe {
         let Ok(snapshot) = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0) else {
             return found;
@@ -49,8 +46,7 @@ pub fn ids_of(wanted: impl Fn(&str) -> bool) -> Vec<u32> {
 /// Closes a process.
 ///
 /// A process that has already gone, or one we are not allowed to close, is not
-/// reported: the reason for closing it was to have it gone, and both of those
-/// mean it is not in the way any more.
+/// reported: either way it is not in the way any more.
 pub fn terminate(process: u32) {
     // SAFETY: the handle is closed on every path that opened it.
     unsafe {

--- a/src/driver/process.rs
+++ b/src/driver/process.rs
@@ -3,11 +3,18 @@
 //!
 //! Whose processes are worth closing is decided by the modules that ask.
 
-use windows::Win32::Foundation::CloseHandle;
+use windows::core::PWSTR;
+use windows::Win32::Foundation::{CloseHandle, HANDLE};
 use windows::Win32::System::Diagnostics::ToolHelp::{
     CreateToolhelp32Snapshot, Process32FirstW, Process32NextW, PROCESSENTRY32W, TH32CS_SNAPPROCESS,
 };
-use windows::Win32::System::Threading::{OpenProcess, TerminateProcess, PROCESS_TERMINATE};
+use windows::Win32::System::Threading::{
+    OpenProcess, QueryFullProcessImageNameW, TerminateProcess, PROCESS_NAME_WIN32,
+    PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_TERMINATE,
+};
+
+/// Long enough for any path Windows will hand back, including the long ones.
+const LONGEST_PATH: usize = 1024;
 
 /// The ids of the running processes whose file name `wanted` accepts.
 ///
@@ -43,20 +50,64 @@ pub fn ids_of(wanted: impl Fn(&str) -> bool) -> Vec<u32> {
     found
 }
 
-/// Closes a process.
+/// Closes a process, but only if its image name is still one `wanted` accepts.
+///
+/// The id alone is not evidence of what a process is. Windows hands ids out
+/// again as soon as they are free, and every caller here listed the process
+/// some time before deciding to close it - the watchdog does so about once a
+/// second for as long as the program runs. Between the listing and the call the
+/// process can exit and its id be given to something else, which this program
+/// would then close while running as an administrator.
+///
+/// The name is therefore read back from the very handle that is about to be
+/// used, not from the id: the handle keeps the process it named, so nothing can
+/// change between the question and the answer.
 ///
 /// A process that has already gone, or one we are not allowed to close, is not
 /// reported: either way it is not in the way any more.
-pub fn terminate(process: u32) {
+pub fn terminate(process: u32, wanted: impl Fn(&str) -> bool) {
     // SAFETY: the handle is closed on every path that opened it.
     unsafe {
-        let Ok(handle) = OpenProcess(PROCESS_TERMINATE, false, process) else {
+        let Ok(handle) = OpenProcess(
+            PROCESS_TERMINATE | PROCESS_QUERY_LIMITED_INFORMATION,
+            false,
+            process,
+        ) else {
             return;
         };
 
-        let _ = TerminateProcess(handle, 0);
+        if image_name(handle).is_some_and(|name| wanted(&name)) {
+            let _ = TerminateProcess(handle, 0);
+        }
+
         let _ = CloseHandle(handle);
     }
+}
+
+/// The file name of the running image behind a handle, without its directory.
+///
+/// `None` when Windows will not say - a process that is already exiting, or one
+/// this program may not ask about. Nothing is closed on an answer like that.
+fn image_name(handle: HANDLE) -> Option<String> {
+    let mut buffer = [0u16; LONGEST_PATH];
+    let mut written = buffer.len() as u32;
+
+    // SAFETY: the buffer is described with its real length, and Windows writes
+    // back how much of it was used.
+    unsafe {
+        QueryFullProcessImageNameW(
+            handle,
+            PROCESS_NAME_WIN32,
+            PWSTR(buffer.as_mut_ptr()),
+            &mut written,
+        )
+        .ok()?;
+    }
+
+    let path = String::from_utf16_lossy(&buffer[..written as usize]);
+    let name = path.rsplit(['\\', '/']).next()?;
+
+    Some(name.to_owned())
 }
 
 /// The file name Windows reports for a process, without the padding that
@@ -95,14 +146,47 @@ mod tests {
     /// Every machine runs at least the process asking the question.
     #[test]
     fn the_listing_finds_the_program_that_is_asking() {
-        let ours = std::env::current_exe()
+        assert!(!ids_of(|name| name.eq_ignore_ascii_case(&ours())).is_empty());
+    }
+
+    /// The process this test runs in is the one case where the outcome of a
+    /// refused termination can be observed: reaching the next line is it.
+    #[test]
+    fn a_process_whose_name_is_not_wanted_is_left_running() {
+        terminate(std::process::id(), |name| {
+            name == "no_such_process_of_ours.exe"
+        });
+    }
+
+    /// Whatever the predicate says, an id nothing is running under closes
+    /// nothing. Id 0 belongs to the idle process and cannot be opened.
+    #[test]
+    fn an_id_that_names_nothing_closes_nothing() {
+        terminate(0, |_| true);
+    }
+
+    /// The check has to see the same name the listing did, or the callers would
+    /// pass a predicate that never matches and close nothing at all.
+    #[test]
+    fn the_name_read_from_a_handle_is_the_one_the_listing_reports() {
+        // SAFETY: a pseudo handle to this process; nothing is opened or closed.
+        let ourselves =
+            unsafe { windows::Win32::System::Threading::GetCurrentProcess() };
+
+        assert_eq!(
+            image_name(ourselves).map(|name| name.to_lowercase()),
+            Some(ours().to_lowercase())
+        );
+    }
+
+    /// The file name of the running test binary.
+    fn ours() -> String {
+        std::env::current_exe()
             .ok()
             .and_then(|path| {
                 path.file_name()
                     .map(|name| name.to_string_lossy().to_string())
             })
-            .unwrap_or_default();
-
-        assert!(!ids_of(|name| name.eq_ignore_ascii_case(&ours)).is_empty());
+            .unwrap_or_default()
     }
 }

--- a/src/driver/reboot.rs
+++ b/src/driver/reboot.rs
@@ -1,14 +1,13 @@
 //! Remembering, across a reboot, that a reboot is still owed.
 //!
 //! Removing the driver leaves the .sys images loaded in the kernel until the
-//! machine restarts. A volatile registry value is nearly the whole answer: it
-//! survives the program exiting and disappears when Windows starts again.
+//! machine restarts. A volatile registry value survives the program exiting and
+//! disappears when Windows starts again.
 //!
-//! "Nearly", because the value is only volatile while the key that holds it is,
-//! and `REG_OPTION_VOLATILE` is honoured when the key is *created*. A key left
-//! behind by an older build - or created by anything else under the same name -
-//! would keep the flag forever, and the program would refuse to start for good.
-//! So the flag is also cleared explicitly, the moment the driver answers again.
+//! `REG_OPTION_VOLATILE` is honoured only when the key is *created*, so a key
+//! left behind by an older build would keep the flag forever and the program
+//! would refuse to start for good. The flag is therefore also cleared
+//! explicitly, the moment the driver answers again.
 
 use std::process::Command;
 
@@ -33,13 +32,9 @@ pub fn mark_restart_pending() {
 
     // SAFETY: the key is closed below; every pointer outlives the call.
     unsafe {
-        // Delete any existing key first, so the create below always makes a
-        // fresh one - and `REG_OPTION_VOLATILE` is honoured only for a key that
-        // is created. A persistent key left by an older build, or by anything
-        // else under this name, would otherwise keep the flag across the very
-        // restart meant to clear it and strand the program on the "please
-        // restart" screen for good. The key is ours and holds only this flag, so
-        // deleting it loses nothing, and a key that was not there is no error.
+        // Deleted first so the create below always makes a fresh - and
+        // therefore volatile - key. The key is ours and holds only this flag,
+        // and a key that was not there is no error.
         let _ = RegDeleteKeyExW(
             HKEY_LOCAL_MACHINE,
             PCWSTR(path.as_ptr()),
@@ -75,8 +70,7 @@ pub fn mark_restart_pending() {
 }
 
 /// Forgets the flag. Called when the driver is up and answering, which is the
-/// one situation in which a restart cannot still be owed - whether the machine
-/// was restarted or the driver was simply installed again.
+/// one situation in which a restart cannot still be owed.
 pub fn clear_restart_pending() {
     let path = wide(KEY_PATH);
     let name = wide(VALUE_NAME);

--- a/src/driver/reboot.rs
+++ b/src/driver/reboot.rs
@@ -19,7 +19,7 @@ use windows::Win32::System::Registry::{
     REG_OPTION_VOLATILE, REG_SAM_FLAGS,
 };
 
-use super::wide;
+use super::{system32, wide};
 
 const KEY_PATH: &str = r"SOFTWARE\InputRedirect";
 const VALUE_NAME: &str = "RestartPending";
@@ -133,7 +133,7 @@ pub fn is_restart_pending() -> bool {
 
 /// Asks Windows to restart, giving the user a few seconds to read why.
 pub fn request_restart() -> bool {
-    Command::new("shutdown.exe")
+    Command::new(system32("shutdown.exe"))
         .args([
             "/r",
             "/t",

--- a/src/hid/keyboard.rs
+++ b/src/hid/keyboard.rs
@@ -20,15 +20,17 @@ bitflags! {
 }
 
 /// The set of keys the virtual keyboard currently reports as held.
+///
+/// No modifiers: a modifier is never redirected, it stays with the physical
+/// keyboard, so the modifier byte of the report is always zero. Sending our own
+/// would mean holding a modifier Windows already believes is held.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct KeyboardReport {
-    modifiers: Modifiers,
     keys: [u8; MAX_PRESSED_KEYS],
 }
 
 impl KeyboardReport {
     pub const EMPTY: Self = Self {
-        modifiers: Modifiers::empty(),
         keys: [0; MAX_PRESSED_KEYS],
     };
 
@@ -67,7 +69,6 @@ impl KeyboardReport {
     /// the report knows what the virtual keyboard is really holding.
     #[must_use]
     pub fn holds(self, usage: u8) -> bool {
-        // Zero is an empty slot, not a key, exactly as `press` refuses it.
         usage != 0 && self.keys.contains(&usage)
     }
 
@@ -75,10 +76,10 @@ impl KeyboardReport {
         *self = Self::EMPTY;
     }
 
+    /// Byte 0 is the modifier bitmap and byte 1 is reserved; both stay zero.
     #[must_use]
     pub fn to_bytes(self) -> [u8; KEYBOARD_REPORT_LEN] {
         let mut bytes = [0u8; KEYBOARD_REPORT_LEN];
-        bytes[0] = self.modifiers.bits();
         bytes[2..].copy_from_slice(&self.keys);
         bytes
     }
@@ -98,8 +99,18 @@ mod tests {
         let mut report = KeyboardReport::EMPTY;
         assert!(report.press(0x04)); // "a"
 
-        // Byte 0 is the modifier bitmap, byte 1 is reserved, keys start at 2.
         assert_eq!(report.to_bytes(), [0x00, 0x00, 0x04, 0, 0, 0, 0, 0]);
+    }
+
+    /// The virtual keyboard must never claim a modifier of its own: the real
+    /// one is already holding it, and Windows would see it twice.
+    #[test]
+    fn no_report_ever_claims_a_modifier() {
+        let mut report = KeyboardReport::EMPTY;
+        for usage in [0x04, 0xE0, 0xE1, 0xE5] {
+            report.press(usage);
+            assert_eq!(report.to_bytes()[0], 0x00);
+        }
     }
 
     #[test]

--- a/src/hid/keyboard.rs
+++ b/src/hid/keyboard.rs
@@ -32,11 +32,9 @@ impl KeyboardReport {
         keys: [0; MAX_PRESSED_KEYS],
     };
 
-    /// Returns `false` when all six slots are taken - the HID equivalent of a
-    /// keyboard that cannot report one more simultaneous key.
+    /// Returns `false` when all six slots are taken.
     pub fn press(&mut self, usage: u8) -> bool {
-        // Zero is how an empty slot is spelled, so it can never be a key: the
-        // press is refused rather than filling the report with nothing.
+        // Zero is how an empty slot is spelled, so it can never be a key.
         if usage == 0 {
             return false;
         }
@@ -63,11 +61,10 @@ impl KeyboardReport {
         }
     }
 
-    /// Whether this key is currently one of the held slots.
+    /// Whether this key is one of the held slots.
     ///
-    /// The release path asks this rather than trusting a separate record of
-    /// what was pressed: only the report knows what the virtual keyboard is
-    /// really holding, and a key must be let go of there if, and only if, it is.
+    /// The release path asks this rather than trusting a separate record: only
+    /// the report knows what the virtual keyboard is really holding.
     #[must_use]
     pub fn holds(self, usage: u8) -> bool {
         // Zero is an empty slot, not a key, exactly as `press` refuses it.
@@ -156,7 +153,7 @@ mod tests {
         report.release(0x04);
         assert!(!report.holds(0x04));
 
-        // Zero is the empty slot, never a held key, however many slots are free.
+        // Zero is the empty slot, never a held key.
         assert!(!report.holds(0));
     }
 

--- a/src/redirect/combo.rs
+++ b/src/redirect/combo.rs
@@ -38,16 +38,23 @@ impl ComboWatcher {
 
     /// Whether the press being handled belongs to a shortcut.
     ///
-    /// `live` reports the modifiers really held, and is asked only when this
-    /// watcher believes one is down - the one belief that can be wrong. A
+    /// `still_held` is given what this watcher believes and answers with the
+    /// part of it Windows agrees is really down. It is asked only when
+    /// something is believed held - the one belief that can be wrong. A
     /// modifier released while another desktop had the keyboard is never seen
     /// here, and would otherwise be believed held for the rest of the session.
-    pub fn press_belongs_to_shortcut(&mut self, live: impl FnOnce() -> Modifiers) -> bool {
+    ///
+    /// Nothing outside the believed set is worth asking about: it is about to
+    /// be intersected away.
+    pub fn press_belongs_to_shortcut(
+        &mut self,
+        still_held: impl FnOnce(Modifiers) -> Modifiers,
+    ) -> bool {
         if self.held_modifiers.is_empty() {
             return false;
         }
 
-        self.held_modifiers &= live();
+        self.held_modifiers &= still_held(self.held_modifiers);
 
         !self.held_modifiers.is_empty()
     }
@@ -67,14 +74,9 @@ mod tests {
     const KEY_A: u8 = 0x04;
     const KEY_C: u8 = 0x06;
 
-    /// Stands in for the real keyboard agreeing with everything the hook saw.
-    fn honest(watcher: &ComboWatcher) -> Modifiers {
-        watcher.held_modifiers
-    }
-
+    /// The real keyboard agreeing with everything the hook saw.
     fn belongs_to_shortcut(watcher: &mut ComboWatcher) -> bool {
-        let live = honest(watcher);
-        watcher.press_belongs_to_shortcut(|| live)
+        watcher.press_belongs_to_shortcut(|believed| believed)
     }
 
     #[test]
@@ -135,7 +137,7 @@ mod tests {
         watcher.note(LEFT_CTRL, true);
 
         // Windows says nothing is held any more: the release went elsewhere.
-        assert!(!watcher.press_belongs_to_shortcut(Modifiers::empty));
+        assert!(!watcher.press_belongs_to_shortcut(|_| Modifiers::empty()));
 
         // And the watcher believes it from now on, without asking again.
         assert!(!belongs_to_shortcut(&mut watcher));
@@ -148,8 +150,21 @@ mod tests {
         watcher.note(LEFT_CTRL, true);
         watcher.note(LEFT_ALT, true);
 
-        assert!(watcher.press_belongs_to_shortcut(|| Modifiers::LEFT_ALT));
+        assert!(watcher.press_belongs_to_shortcut(|_| Modifiers::LEFT_ALT));
         assert_eq!(watcher.held_modifiers, Modifiers::LEFT_ALT);
+    }
+
+    /// Windows is only ever asked about what is believed held, because that is
+    /// all the intersection can keep.
+    #[test]
+    fn only_the_modifiers_believed_held_are_asked_about() {
+        let mut watcher = ComboWatcher::default();
+        watcher.note(LEFT_CTRL, true);
+
+        watcher.press_belongs_to_shortcut(|believed| {
+            assert_eq!(believed, Modifiers::LEFT_CTRL);
+            believed
+        });
     }
 
     /// Nothing is asked of Windows on the path every keystroke takes.
@@ -158,6 +173,6 @@ mod tests {
         let mut watcher = ComboWatcher::default();
         watcher.note(KEY_A, true);
 
-        assert!(!watcher.press_belongs_to_shortcut(|| panic!("asked Windows for nothing")));
+        assert!(!watcher.press_belongs_to_shortcut(|_| panic!("asked Windows for nothing")));
     }
 }

--- a/src/redirect/combo.rs
+++ b/src/redirect/combo.rs
@@ -1,18 +1,15 @@
 //! Deciding which keys are part of a shortcut.
 //!
 //! Rebuilding a shortcut on the virtual keyboard is unreliable: the modifier is
-//! seen by Windows on one device and the letter on another, and some
-//! combinations - the secure attention sequence above all - are never delivered
-//! at all. So while a modifier is held, the keyboard is left alone.
+//! seen on one device and the letter on another, and some combinations - the
+//! secure attention sequence above all - are never delivered. So while a
+//! modifier is held, the keyboard is left alone.
 //!
-//! This runs inside the low level keyboard hook, where every millisecond spent
-//! is a millisecond of input lag for the whole desktop, so the set of held
-//! modifiers is a single bitflag and nothing here allocates.
+//! This runs inside the low level keyboard hook, so the set of held modifiers
+//! is a single bitflag and nothing here allocates.
 //!
 //! Only presses are decided here. A release is decided by what the virtual
-//! keyboard is actually holding, which the report itself knows and this watcher
-//! cannot: a key can reach Windows without ever being pressed on the virtual
-//! device, and its release then has to follow it there.
+//! keyboard is actually holding, which only the report knows.
 
 use crate::hid::{modifier_of, Modifiers};
 
@@ -24,9 +21,9 @@ pub struct ComboWatcher {
 impl ComboWatcher {
     /// Records a modifier going down or up.
     ///
-    /// Has to be called for every key, modifier or not, and before anything
-    /// else looks at the watcher: the set of held modifiers is what every press
-    /// after it is judged against.
+    /// Has to be called for every key, and before anything else looks at the
+    /// watcher: the set of held modifiers is what later presses are judged
+    /// against.
     pub fn note(&mut self, usage: u8, pressed: bool) {
         let Some(modifier) = modifier_of(usage) else {
             return;
@@ -39,17 +36,12 @@ impl ComboWatcher {
         }
     }
 
-    /// Whether the press being handled belongs to a shortcut, and so has to be
-    /// left to Windows.
+    /// Whether the press being handled belongs to a shortcut.
     ///
-    /// `live` reports the modifiers really held right now, and is asked only
-    /// when this watcher believes one is down - which is the belief that can be
-    /// wrong, and the only case where the answer is not already "redirect it".
-    /// A modifier released while another desktop had the keyboard - the lock
-    /// screen, the secure attention sequence, a prompt for administrator
-    /// rights - is never seen by this hook, and without this the watcher would
-    /// go on believing it held for the rest of the session, quietly leaving
-    /// every keystroke to Windows while the screen says the redirect is on.
+    /// `live` reports the modifiers really held, and is asked only when this
+    /// watcher believes one is down - the one belief that can be wrong. A
+    /// modifier released while another desktop had the keyboard is never seen
+    /// here, and would otherwise be believed held for the rest of the session.
     pub fn press_belongs_to_shortcut(&mut self, live: impl FnOnce() -> Modifiers) -> bool {
         if self.held_modifiers.is_empty() {
             return false;
@@ -60,8 +52,7 @@ impl ComboWatcher {
         !self.held_modifiers.is_empty()
     }
 
-    /// Forgets modifiers that were held when the redirect was switched off, so
-    /// the next session does not start out thinking one is still down.
+    /// Forgets modifiers held when the redirect was switched off.
     pub fn clear(&mut self) {
         self.held_modifiers = Modifiers::empty();
     }
@@ -137,8 +128,7 @@ mod tests {
     }
 
     /// The lock screen takes the keyboard away and gives back a modifier that
-    /// was never released here. Believing it forever is what used to leave the
-    /// redirect switched on and doing nothing.
+    /// was never released here.
     #[test]
     fn a_modifier_released_on_another_desktop_stops_holding_the_redirect_back() {
         let mut watcher = ComboWatcher::default();
@@ -151,8 +141,7 @@ mod tests {
         assert!(!belongs_to_shortcut(&mut watcher));
     }
 
-    /// Only the modifier that really went away is forgotten - one the user is
-    /// still holding keeps its shortcut.
+    /// Only the modifier that really went away is forgotten.
     #[test]
     fn a_modifier_that_is_still_held_survives_the_reconciliation() {
         let mut watcher = ComboWatcher::default();
@@ -163,8 +152,7 @@ mod tests {
         assert_eq!(watcher.held_modifiers, Modifiers::LEFT_ALT);
     }
 
-    /// Nothing is asked of Windows on the path every keystroke takes, which is
-    /// the one that must stay short.
+    /// Nothing is asked of Windows on the path every keystroke takes.
     #[test]
     fn the_common_case_never_asks_what_is_really_held() {
         let mut watcher = ComboWatcher::default();

--- a/src/redirect/echo.rs
+++ b/src/redirect/echo.rs
@@ -2,23 +2,21 @@
 //!
 //! The virtual keyboard and mouse are real HID devices, so everything they
 //! report arrives at the hooks a moment later. Each injected event is counted
-//! here and the matching echo is let through untouched; without this the first
-//! key press would loop forever.
+//! here and the matching echo is let through; without this the first key press
+//! would loop forever.
 
 use std::collections::HashMap;
 use std::time::{Duration, Instant};
 
 use crate::hid::MouseButtons;
 
-/// How many echoes may pile up for one key before the oldest are forgotten.
-/// A backlog can only mean the echo never arrived - a lost event is better
-/// than a key that stays swallowed.
+/// How many echoes may pile up for one key before the oldest are forgotten. A
+/// backlog can only mean the echo never arrived.
 const MAX_PENDING: u8 = 8;
 
 /// How long an expected echo stays expected. The driver answers in about a
-/// millisecond; anything still waiting after this never arrived, and holding on
-/// to it would swallow a real key press the user makes later. The cap above is
-/// not enough on its own: a key pressed once and lost keeps its single count
+/// millisecond, and holding on longer would swallow a real key press. The cap
+/// above is not enough on its own: a single lost count would otherwise wait
 /// until the same key is pressed again, which may be minutes later.
 const ECHO_LIFETIME: Duration = Duration::from_millis(50);
 
@@ -63,8 +61,7 @@ impl EchoFilter {
     }
 
     /// The two devices are switched on and off separately, so each forgets only
-    /// what it was owed: clearing both would drop echoes the other one is still
-    /// waiting for, and every dropped echo is an event let through as the real
+    /// what it was owed: a dropped echo is an event let through as the real
     /// device's.
     pub fn clear_keys(&mut self) {
         self.keys.clear();
@@ -75,7 +72,7 @@ impl EchoFilter {
     }
 
     // The clock is passed in below so the lifetime above can be tested without
-    // the tests having to sleep through it.
+    // sleeping through it.
 
     fn expect_key_at(&mut self, usage: u8, pressed: bool, now: Instant) {
         increment(&mut self.keys, (usage, pressed), now);
@@ -108,8 +105,8 @@ fn increment(counters: &mut Counters, key: (u8, bool), now: Instant) {
 }
 
 fn decrement(counters: &mut Counters, key: (u8, bool), now: Instant) -> bool {
-    // Checked before taking the entry out mutably: a stale count is dropped
-    // whole, and the event that found it is treated as the user's own.
+    // A stale count is dropped whole, and the event that found it is treated as
+    // the user's own.
     if counters
         .get(&key)
         .is_some_and(|pending| pending.expires_at <= now)

--- a/src/redirect/echo.rs
+++ b/src/redirect/echo.rs
@@ -4,8 +4,10 @@
 //! report arrives at the hooks a moment later. Each injected event is counted
 //! here and the matching echo is let through; without this the first key press
 //! would loop forever.
+//!
+//! Every lookup happens inside a low-level hook, so the counters live in flat
+//! arrays indexed by the event itself: no hashing, no allocation, no resizing.
 
-use std::collections::HashMap;
 use std::time::{Duration, Instant};
 
 use crate::hid::MouseButtons;
@@ -20,6 +22,12 @@ const MAX_PENDING: u8 = 8;
 /// until the same key is pressed again, which may be minutes later.
 const ECHO_LIFETIME: Duration = Duration::from_millis(50);
 
+/// Every HID usage, in both directions.
+const KEY_SLOTS: usize = 256 * 2;
+
+/// Every bit a button flag can occupy, in both directions.
+const BUTTON_SLOTS: usize = 8 * 2;
+
 /// The echoes still owed for one key or button, and when they stop counting.
 #[derive(Clone, Copy, Debug)]
 struct Pending {
@@ -27,12 +35,19 @@ struct Pending {
     expires_at: Instant,
 }
 
-type Counters = HashMap<(u8, bool), Pending>;
-
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct EchoFilter {
-    keys: Counters,
-    buttons: Counters,
+    keys: [Option<Pending>; KEY_SLOTS],
+    buttons: [Option<Pending>; BUTTON_SLOTS],
+}
+
+impl Default for EchoFilter {
+    fn default() -> Self {
+        Self {
+            keys: [None; KEY_SLOTS],
+            buttons: [None; BUTTON_SLOTS],
+        }
+    }
 }
 
 impl EchoFilter {
@@ -64,38 +79,59 @@ impl EchoFilter {
     /// what it was owed: a dropped echo is an event let through as the real
     /// device's.
     pub fn clear_keys(&mut self) {
-        self.keys.clear();
+        self.keys = [None; KEY_SLOTS];
     }
 
     pub fn clear_buttons(&mut self) {
-        self.buttons.clear();
+        self.buttons = [None; BUTTON_SLOTS];
     }
 
     // The clock is passed in below so the lifetime above can be tested without
     // sleeping through it.
 
     fn expect_key_at(&mut self, usage: u8, pressed: bool, now: Instant) {
-        increment(&mut self.keys, (usage, pressed), now);
+        increment(&mut self.keys[slot(usage, pressed)], now);
     }
 
     fn expect_button_at(&mut self, button: MouseButtons, pressed: bool, now: Instant) {
-        increment(&mut self.buttons, (button.bits(), pressed), now);
+        if let Some(index) = button_slot(button, pressed) {
+            increment(&mut self.buttons[index], now);
+        }
     }
 
     fn take_key_at(&mut self, usage: u8, pressed: bool, now: Instant) -> bool {
-        decrement(&mut self.keys, (usage, pressed), now)
+        decrement(&mut self.keys[slot(usage, pressed)], now)
     }
 
     fn take_button_at(&mut self, button: MouseButtons, pressed: bool, now: Instant) -> bool {
-        decrement(&mut self.buttons, (button.bits(), pressed), now)
+        match button_slot(button, pressed) {
+            Some(index) => decrement(&mut self.buttons[index], now),
+            None => false,
+        }
     }
+}
+
+/// Press and release are counted apart, so the direction is the low bit.
+fn slot(index: u8, pressed: bool) -> usize {
+    usize::from(index) << 1 | usize::from(pressed)
+}
+
+/// The hooks report one button at a time; anything else has no slot and is
+/// therefore never an echo of ours.
+fn button_slot(button: MouseButtons, pressed: bool) -> Option<usize> {
+    let bit = button.bits();
+    if !bit.is_power_of_two() {
+        return None;
+    }
+
+    Some(slot(bit.trailing_zeros() as u8, pressed))
 }
 
 /// Each new injection pushes the deadline out, so a held key repeating stays
 /// expected for as long as it repeats.
-fn increment(counters: &mut Counters, key: (u8, bool), now: Instant) {
+fn increment(slot: &mut Option<Pending>, now: Instant) {
     let expires_at = now + ECHO_LIFETIME;
-    let pending = counters.entry(key).or_insert(Pending {
+    let pending = slot.get_or_insert(Pending {
         count: 0,
         expires_at,
     });
@@ -104,27 +140,26 @@ fn increment(counters: &mut Counters, key: (u8, bool), now: Instant) {
     pending.expires_at = expires_at;
 }
 
-fn decrement(counters: &mut Counters, key: (u8, bool), now: Instant) -> bool {
+fn decrement(slot: &mut Option<Pending>, now: Instant) -> bool {
+    let Some(pending) = slot.as_mut() else {
+        return false;
+    };
+
     // A stale count is dropped whole, and the event that found it is treated as
     // the user's own.
-    if counters
-        .get(&key)
-        .is_some_and(|pending| pending.expires_at <= now)
-    {
-        counters.remove(&key);
-        return false;
+    let stale = pending.expires_at <= now;
+    let mut matched = false;
+    if !stale && pending.count > 0 {
+        pending.count -= 1;
+        matched = true;
     }
 
-    match counters.get_mut(&key) {
-        Some(pending) if pending.count > 0 => {
-            pending.count -= 1;
-            if pending.count == 0 {
-                counters.remove(&key);
-            }
-            true
-        }
-        _ => false,
+    let spent = stale || pending.count == 0;
+    if spent {
+        *slot = None;
     }
+
+    matched
 }
 
 #[cfg(test)]
@@ -166,6 +201,19 @@ mod tests {
         filter.expect_key(0x04, true);
 
         assert!(!filter.take_key(0x05, true));
+    }
+
+    /// The slot arithmetic has to hold at both ends of the usage range.
+    #[test]
+    fn every_usage_has_a_slot_of_its_own() {
+        let mut filter = EchoFilter::default();
+        for usage in [0x00, 0x01, 0x7F, 0xFE, 0xFF] {
+            for pressed in [true, false] {
+                filter.expect_key(usage, pressed);
+                assert!(filter.take_key(usage, pressed));
+                assert!(!filter.take_key(usage, pressed));
+            }
+        }
     }
 
     #[test]
@@ -223,6 +271,36 @@ mod tests {
         assert!(!filter.take_button(MouseButtons::RIGHT, true));
         assert!(filter.take_button(MouseButtons::LEFT, true));
         assert!(!filter.take_button(MouseButtons::LEFT, true));
+    }
+
+    /// Each flag the hooks can report gets a slot, and no two share one.
+    #[test]
+    fn every_button_has_a_slot_of_its_own() {
+        let buttons = [
+            MouseButtons::LEFT,
+            MouseButtons::RIGHT,
+            MouseButtons::MIDDLE,
+            MouseButtons::BACK,
+            MouseButtons::FORWARD,
+        ];
+
+        let mut filter = EchoFilter::default();
+        for button in buttons {
+            filter.expect_button(button, true);
+        }
+        for button in buttons {
+            assert!(filter.take_button(button, true), "{button:?}");
+        }
+    }
+
+    /// Nothing the hooks send looks like this, and it must not be mistaken for
+    /// an echo if it ever does.
+    #[test]
+    fn an_event_for_no_button_at_all_is_not_an_echo() {
+        let mut filter = EchoFilter::default();
+        filter.expect_button(MouseButtons::empty(), true);
+
+        assert!(!filter.take_button(MouseButtons::empty(), true));
     }
 
     #[test]

--- a/src/redirect/hook.rs
+++ b/src/redirect/hook.rs
@@ -15,17 +15,25 @@ use windows::Win32::UI::Input::KeyboardAndMouse::{
     VK_RMENU, VK_RSHIFT, VK_RWIN,
 };
 use windows::Win32::UI::WindowsAndMessaging::{
-    CallNextHookEx, DispatchMessageW, GetMessageW, PostThreadMessageW, SetWindowsHookExW,
-    TranslateMessage, UnhookWindowsHookEx, HHOOK, KBDLLHOOKSTRUCT, MSG, MSLLHOOKSTRUCT,
-    WH_KEYBOARD_LL, WH_MOUSE_LL, WM_KEYDOWN, WM_LBUTTONDOWN, WM_LBUTTONUP, WM_MBUTTONDOWN,
-    WM_MBUTTONUP, WM_QUIT, WM_RBUTTONDOWN, WM_RBUTTONUP, WM_SYSKEYDOWN, WM_XBUTTONDOWN,
-    WM_XBUTTONUP, XBUTTON1,
+    CallNextHookEx, DispatchMessageW, GetMessageW, KillTimer, PostThreadMessageW, SetTimer,
+    SetWindowsHookExW, TranslateMessage, UnhookWindowsHookEx, HHOOK, HOOKPROC, KBDLLHOOKSTRUCT,
+    MSG, MSLLHOOKSTRUCT, WH_KEYBOARD_LL, WH_MOUSE_LL, WINDOWS_HOOK_ID, WM_KEYDOWN, WM_LBUTTONDOWN,
+    WM_LBUTTONUP, WM_MBUTTONDOWN, WM_MBUTTONUP, WM_QUIT, WM_RBUTTONDOWN, WM_RBUTTONUP,
+    WM_SYSKEYDOWN, WM_TIMER, WM_XBUTTONDOWN, WM_XBUTTONUP, XBUTTON1,
 };
 
 use crate::error::{Error, Result};
 use crate::hid::{Modifiers, MouseButtons};
 
 use super::{on_button, on_key, Decision};
+
+/// How often the hooks are replaced. Windows drops a low-level hook whose
+/// callback overran `LowLevelHooksTimeout` and says nothing about it, and no
+/// call reports whether a handle is still in the chain.
+///
+/// Long enough to cost nothing, short enough that a redirect that has been cut
+/// off comes back before the user gives up on it.
+const REARM_INTERVAL_MS: u32 = 30_000;
 
 /// One entry per bit in [`Modifiers`], by the key that stands for that side.
 ///
@@ -144,7 +152,7 @@ fn run(ready: &Sender<Option<u32>>) {
         let keyboard = SetWindowsHookExW(WH_KEYBOARD_LL, Some(keyboard_hook), None, 0);
         let mouse = SetWindowsHookExW(WH_MOUSE_LL, Some(mouse_hook), None, 0);
 
-        let (Ok(keyboard), Ok(mouse)) = (keyboard, mouse) else {
+        let (Ok(mut keyboard), Ok(mut mouse)) = (keyboard, mouse) else {
             // Whichever one Windows did accept has to come back down here.
             // This thread is about to end, and Windows goes on calling a hook
             // whose owner is gone until it times out - with the only handle
@@ -157,6 +165,10 @@ fn run(ready: &Sender<Option<u32>>) {
 
         let _ = ready.send(Some(GetCurrentThreadId()));
 
+        // A thread timer: no window, so the message arrives here rather than
+        // through a window procedure. Zero asks Windows to pick the id.
+        let timer = SetTimer(None, 0, REARM_INTERVAL_MS, None);
+
         let mut message = MSG::default();
         loop {
             // Three answers, not two: a positive number is a message, zero is
@@ -167,12 +179,38 @@ fn run(ready: &Sender<Option<u32>>) {
                 break;
             }
 
+            if message.message == WM_TIMER {
+                rearm(WH_KEYBOARD_LL, &mut keyboard, Some(keyboard_hook));
+                rearm(WH_MOUSE_LL, &mut mouse, Some(mouse_hook));
+                continue;
+            }
+
             let _ = TranslateMessage(&message);
             DispatchMessageW(&message);
         }
 
+        if timer != 0 {
+            let _ = KillTimer(None, timer);
+        }
+
         take_down([Ok(keyboard), Ok(mouse)]);
     }
+}
+
+/// Puts a fresh hook in place of `current`, in case Windows has quietly
+/// dropped it.
+///
+/// The new one goes in before the old one comes out, so the chain is never
+/// without a hook of ours; and if Windows refuses the new one, the old handle
+/// is left exactly as it was rather than thrown away.
+fn rearm(kind: WINDOWS_HOOK_ID, current: &mut HHOOK, callback: HOOKPROC) {
+    // SAFETY: called on the thread that owns these hooks, which is the only
+    // thread allowed to install or remove them.
+    let Ok(fresh) = (unsafe { SetWindowsHookExW(kind, callback, None, 0) }) else {
+        return;
+    };
+
+    take_down([Ok(std::mem::replace(current, fresh))]);
 }
 
 /// Removes the hooks that were installed, ignoring the ones that were not.
@@ -333,6 +371,15 @@ mod tests {
         let believed = Modifiers::LEFT_CTRL | Modifiers::RIGHT_SHIFT;
 
         assert!(still_held(believed).difference(believed).is_empty());
+    }
+
+    /// Replacing the hooks costs a pair of calls, so the interval has to stay
+    /// far above the timeout that makes it necessary in the first place.
+    #[test]
+    fn the_hooks_are_replaced_rarely_enough_to_cost_nothing() {
+        let default_timeout_ms = 300;
+
+        assert!(REARM_INTERVAL_MS >= 30 * default_timeout_ms);
     }
 
     /// The failure path hands take_down whatever the two calls returned, and a

--- a/src/redirect/hook.rs
+++ b/src/redirect/hook.rs
@@ -384,8 +384,8 @@ mod tests {
         assert!(REARM_INTERVAL_MS >= 30 * default_timeout_ms);
     }
 
-    /// The failure path hands take_down whatever the two calls produced, and a
-    /// hook that was never installed must not be removed.
+    /// The failure path hands `take_down` whatever the two calls produced, and
+    /// a hook that was never installed must not be removed.
     #[test]
     fn taking_down_hooks_that_were_never_installed_does_nothing() {
         take_down([None]);

--- a/src/redirect/hook.rs
+++ b/src/redirect/hook.rs
@@ -16,9 +16,10 @@ use windows::Win32::UI::Input::KeyboardAndMouse::{
 };
 use windows::Win32::UI::WindowsAndMessaging::{
     CallNextHookEx, DispatchMessageW, GetMessageW, PostThreadMessageW, SetWindowsHookExW,
-    TranslateMessage, UnhookWindowsHookEx, KBDLLHOOKSTRUCT, MSG, MSLLHOOKSTRUCT, WH_KEYBOARD_LL,
-    WH_MOUSE_LL, WM_KEYDOWN, WM_LBUTTONDOWN, WM_LBUTTONUP, WM_MBUTTONDOWN, WM_MBUTTONUP, WM_QUIT,
-    WM_RBUTTONDOWN, WM_RBUTTONUP, WM_SYSKEYDOWN, WM_XBUTTONDOWN, WM_XBUTTONUP, XBUTTON1,
+    TranslateMessage, UnhookWindowsHookEx, HHOOK, KBDLLHOOKSTRUCT, MSG, MSLLHOOKSTRUCT,
+    WH_KEYBOARD_LL, WH_MOUSE_LL, WM_KEYDOWN, WM_LBUTTONDOWN, WM_LBUTTONUP, WM_MBUTTONDOWN,
+    WM_MBUTTONUP, WM_QUIT, WM_RBUTTONDOWN, WM_RBUTTONUP, WM_SYSKEYDOWN, WM_XBUTTONDOWN,
+    WM_XBUTTONUP, XBUTTON1,
 };
 
 use crate::error::{Error, Result};
@@ -28,8 +29,8 @@ use super::{on_button, on_key, Decision};
 
 /// One entry per bit in [`Modifiers`], by the key that stands for that side.
 ///
-/// The sided virtual keys are the only ones that will do: the merged `VK_CONTROL`
-/// and friends answer for either side at once, and could never clear just one.
+/// The sided virtual keys are the only ones that will do: the merged
+/// `VK_CONTROL` and friends answer for either side at once.
 const SIDED_MODIFIERS: [(VIRTUAL_KEY, Modifiers); 8] = [
     (VK_LCONTROL, Modifiers::LEFT_CTRL),
     (VK_LSHIFT, Modifiers::LEFT_SHIFT),
@@ -46,11 +47,10 @@ const SIDED_MODIFIERS: [(VIRTUAL_KEY, Modifiers); 8] = [
 /// Asked only when the combo watcher believes a modifier is down, so the path
 /// every ordinary keystroke takes never reaches it.
 ///
-/// The async key state is the right thing to ask: it belongs to the session
-/// rather than to a window, so it is still right after the keyboard has been
-/// somewhere this hook cannot follow. `GetKeyboardState` would not do - it
-/// answers for the calling thread's input queue, and the hook thread is not
-/// attached to the one the user is typing into.
+/// The async key state belongs to the session rather than to a window, so it is
+/// still right after the keyboard has been somewhere this hook cannot follow.
+/// `GetKeyboardState` answers for the calling thread's input queue, and the
+/// hook thread is not attached to the one the user is typing into.
 pub fn live_modifiers() -> Modifiers {
     let mut held = Modifiers::empty();
 
@@ -58,7 +58,7 @@ pub fn live_modifiers() -> Modifiers {
         // SAFETY: the call takes a virtual key code and no pointer or handle.
         let state = unsafe { GetAsyncKeyState(i32::from(key.0)) };
 
-        // The high bit is "down now"; the low one only means "pressed since
+        // The high bit is "down now". The low one only means "pressed since
         // this was last asked", which is a different question.
         if state as u16 & 0x8000 != 0 {
             held.insert(modifier);
@@ -139,6 +139,12 @@ fn run(ready: &Sender<Option<u32>>) {
         let mouse = SetWindowsHookExW(WH_MOUSE_LL, Some(mouse_hook), None, 0);
 
         let (Ok(keyboard), Ok(mouse)) = (keyboard, mouse) else {
+            // Whichever one Windows did accept has to come back down here.
+            // This thread is about to end, and Windows goes on calling a hook
+            // whose owner is gone until it times out - with the only handle
+            // that could remove it dropped along with this frame.
+            take_down([keyboard, mouse]);
+
             let _ = ready.send(None);
             return;
         };
@@ -159,8 +165,21 @@ fn run(ready: &Sender<Option<u32>>) {
             DispatchMessageW(&message);
         }
 
-        let _ = UnhookWindowsHookEx(keyboard);
-        let _ = UnhookWindowsHookEx(mouse);
+        take_down([Ok(keyboard), Ok(mouse)]);
+    }
+}
+
+/// Removes the hooks that were installed, ignoring the ones that were not.
+///
+/// Must run on the thread that installed them, which is the only one allowed
+/// to remove them.
+fn take_down<const N: usize>(hooks: [windows::core::Result<HHOOK>; N]) {
+    for hook in hooks.into_iter().flatten() {
+        // SAFETY: each handle came from SetWindowsHookExW on this thread and is
+        // removed exactly once.
+        unsafe {
+            let _ = UnhookWindowsHookEx(hook);
+        }
     }
 }
 
@@ -283,5 +302,13 @@ mod tests {
     #[test]
     fn a_callback_that_works_keeps_its_answer() {
         assert_eq!(decided_safely(|| Decision::Swallow), Decision::Swallow);
+    }
+
+    /// The failure path hands take_down whatever the two calls returned, and a
+    /// hook that was never installed must not be removed.
+    #[test]
+    fn taking_down_hooks_that_were_never_installed_does_nothing() {
+        take_down([Err(windows::core::Error::from_win32())]);
+        take_down::<0>([]);
     }
 }

--- a/src/redirect/hook.rs
+++ b/src/redirect/hook.rs
@@ -42,19 +42,25 @@ const SIDED_MODIFIERS: [(VIRTUAL_KEY, Modifiers); 8] = [
     (VK_RWIN, Modifiers::RIGHT_GUI),
 ];
 
-/// The modifiers Windows itself reports as held right now.
+/// Which of `believed` Windows still reports as held.
 ///
-/// Asked only when the combo watcher believes a modifier is down, so the path
-/// every ordinary keystroke takes never reaches it.
+/// Only the bits in `believed` are asked about. The caller intersects the
+/// answer with that same set, so anything outside it would be read and thrown
+/// away - and this runs inside the low-level keyboard hook, where every call
+/// out is time the whole system's input waits for.
 ///
 /// The async key state belongs to the session rather than to a window, so it is
 /// still right after the keyboard has been somewhere this hook cannot follow.
 /// `GetKeyboardState` answers for the calling thread's input queue, and the
 /// hook thread is not attached to the one the user is typing into.
-pub fn live_modifiers() -> Modifiers {
+pub fn still_held(believed: Modifiers) -> Modifiers {
     let mut held = Modifiers::empty();
 
     for (key, modifier) in SIDED_MODIFIERS {
+        if !believed.contains(modifier) {
+            continue;
+        }
+
         // SAFETY: the call takes a virtual key code and no pointer or handle.
         let state = unsafe { GetAsyncKeyState(i32::from(key.0)) };
 
@@ -302,6 +308,31 @@ mod tests {
     #[test]
     fn a_callback_that_works_keeps_its_answer() {
         assert_eq!(decided_safely(|| Decision::Swallow), Decision::Swallow);
+    }
+
+    /// Believing nothing is held is the common case, and it must not reach
+    /// Windows at all.
+    #[test]
+    fn believing_nothing_is_held_asks_windows_nothing() {
+        assert_eq!(still_held(Modifiers::empty()), Modifiers::empty());
+    }
+
+    /// Whatever the keyboard is really doing, the answer cannot name a
+    /// modifier that was not asked about.
+    #[test]
+    fn the_answer_never_names_a_modifier_that_was_not_believed_held() {
+        for (_, modifier) in SIDED_MODIFIERS {
+            assert!(still_held(modifier).difference(modifier).is_empty());
+        }
+    }
+
+    /// No test can press a key, so this only pins down the shape of the
+    /// answer: a subset of what was asked about.
+    #[test]
+    fn the_answer_is_a_subset_of_what_was_asked_about() {
+        let believed = Modifiers::LEFT_CTRL | Modifiers::RIGHT_SHIFT;
+
+        assert!(still_held(believed).difference(believed).is_empty());
     }
 
     /// The failure path hands take_down whatever the two calls returned, and a

--- a/src/redirect/hook.rs
+++ b/src/redirect/hook.rs
@@ -149,10 +149,12 @@ fn run(ready: &Sender<Option<u32>>) {
     // SAFETY: the hooks are installed and removed on this thread, and the
     // message loop between the two calls is what keeps them alive.
     unsafe {
-        let keyboard = SetWindowsHookExW(WH_KEYBOARD_LL, Some(keyboard_hook), None, 0);
-        let mouse = SetWindowsHookExW(WH_MOUSE_LL, Some(mouse_hook), None, 0);
+        // Only whether a hook exists matters from here on, and a handle is
+        // Copy where a Result is not.
+        let keyboard = SetWindowsHookExW(WH_KEYBOARD_LL, Some(keyboard_hook), None, 0).ok();
+        let mouse = SetWindowsHookExW(WH_MOUSE_LL, Some(mouse_hook), None, 0).ok();
 
-        let (Ok(mut keyboard), Ok(mut mouse)) = (keyboard, mouse) else {
+        let (Some(mut keyboard), Some(mut mouse)) = (keyboard, mouse) else {
             // Whichever one Windows did accept has to come back down here.
             // This thread is about to end, and Windows goes on calling a hook
             // whose owner is gone until it times out - with the only handle
@@ -193,7 +195,7 @@ fn run(ready: &Sender<Option<u32>>) {
             let _ = KillTimer(None, timer);
         }
 
-        take_down([Ok(keyboard), Ok(mouse)]);
+        take_down([Some(keyboard), Some(mouse)]);
     }
 }
 
@@ -210,14 +212,14 @@ fn rearm(kind: WINDOWS_HOOK_ID, current: &mut HHOOK, callback: HOOKPROC) {
         return;
     };
 
-    take_down([Ok(std::mem::replace(current, fresh))]);
+    take_down([Some(std::mem::replace(current, fresh))]);
 }
 
 /// Removes the hooks that were installed, ignoring the ones that were not.
 ///
 /// Must run on the thread that installed them, which is the only one allowed
 /// to remove them.
-fn take_down<const N: usize>(hooks: [windows::core::Result<HHOOK>; N]) {
+fn take_down<const N: usize>(hooks: [Option<HHOOK>; N]) {
     for hook in hooks.into_iter().flatten() {
         // SAFETY: each handle came from SetWindowsHookExW on this thread and is
         // removed exactly once.
@@ -382,11 +384,11 @@ mod tests {
         assert!(REARM_INTERVAL_MS >= 30 * default_timeout_ms);
     }
 
-    /// The failure path hands take_down whatever the two calls returned, and a
+    /// The failure path hands take_down whatever the two calls produced, and a
     /// hook that was never installed must not be removed.
     #[test]
     fn taking_down_hooks_that_were_never_installed_does_nothing() {
-        take_down([Err(windows::core::Error::from_win32())]);
+        take_down([None]);
         take_down::<0>([]);
     }
 }

--- a/src/redirect/mod.rs
+++ b/src/redirect/mod.rs
@@ -3,7 +3,7 @@
 //! The low-level hooks run on their own thread and decide, for every event,
 //! whether to swallow it and repeat it through the driver or to let it pass.
 //! All the state that decision needs lives in [`Shared`] behind one lock, so
-//! the hook callbacks stay short and there is exactly one place to reason about.
+//! the hook callbacks stay short and there is one place to reason about.
 
 mod combo;
 mod echo;
@@ -38,9 +38,9 @@ pub enum Decision {
 
 struct Shared {
     /// Held only while there is something to redirect to. The hooks reach the
-    /// driver from their own thread, so this reference outlives any local one -
-    /// which is why it has to be given back explicitly before the driver can
-    /// be taken apart.
+    /// driver from their own thread, so this reference outlives any local one
+    /// and has to be given back explicitly before the driver can be taken
+    /// apart.
     driver: Option<Arc<Driver>>,
     keyboard_enabled: bool,
     mouse_enabled: bool,
@@ -53,9 +53,9 @@ struct Shared {
 
 static SHARED: OnceLock<Mutex<Shared>> = OnceLock::new();
 
-/// Whether an engine currently owns the shared state. The state itself is a
-/// process-wide singleton, so a second engine would silently reset the first
-/// one's counters and leave its hooks pointing at state it no longer owns.
+/// Whether an engine currently owns the shared state. The state is a
+/// process-wide singleton, so a second engine would reset the first one's
+/// counters and leave its hooks pointing at state it no longer owns.
 static INSTALLED: AtomicBool = AtomicBool::new(false);
 
 /// The shared state, whether or not some thread panicked while holding it.
@@ -200,9 +200,8 @@ impl Engine {
 /// Switches the keyboard redirect and, when switching it off, hands back the
 /// driver that still has keys held down on it.
 ///
-/// Sending the empty report is deliberately left to the caller: it happens
-/// after the lock is released, because the hooks must never wait on a driver
-/// call.
+/// Sending the empty report is left to the caller, after the lock is released:
+/// the hooks must never wait on a driver call.
 fn apply_keyboard(shared: &mut Shared, enabled: bool) -> Option<Arc<Driver>> {
     shared.keyboard_enabled = enabled;
     if enabled {
@@ -234,8 +233,7 @@ fn apply_mouse(shared: &mut Shared, enabled: bool) -> Option<Arc<Driver>> {
 fn release_keyboard_waiting(driver: Option<Arc<Driver>>) {
     if let Some(driver) = driver {
         // A failure here means the connection is closed, which happens only
-        // while the bus is being rebuilt - and that takes the devices with it,
-        // so there is nothing left holding anything down.
+        // while the bus is being rebuilt - and that takes the devices with it.
         let _ = driver.release_keyboard_waiting();
     }
 }
@@ -275,11 +273,8 @@ impl Drop for Engine {
 /// there is no unwinding on that path at all.
 pub fn emergency_stop() {
     // The driver is taken out from under the lock and parked only once it is
-    // let go. `park` sends to the driver and takes the connection lock, and the
-    // hooks must never be left waiting on the state lock while that happens -
-    // the same rule `on_key` and `on_button` keep. It matters most here: this
-    // also runs from the console control handler, where the time before the
-    // process is taken away is short.
+    // let go: `park` sends to the driver and takes the connection lock, and the
+    // hooks must never be left waiting on the state lock while that happens.
     let driver = {
         let Some(mut shared) = state() else {
             return;
@@ -303,9 +298,7 @@ pub fn emergency_stop() {
 /// What is to be done with one key, before anything is sent.
 ///
 /// Kept apart from [`on_key`] so the rules can be exercised without a driver:
-/// every one of them exists because of a way a key once got stuck, and none of
-/// them is reachable from a test while the decision and the driver call are one
-/// piece of code.
+/// every one of them exists because of a way a key once got stuck.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum KeyOutcome {
     /// Let Windows have it.
@@ -357,18 +350,16 @@ fn decide_key(
         // A key it never sent - one passed through under a modifier, or dropped
         // for want of a slot - has its release go to Windows too, in step with
         // its press. Deciding this by what the device holds, rather than by what
-        // the watcher recorded, is what keeps a key from being stranded down on
-        // the virtual keyboard when a modifier is tapped mid-press.
+        // the watcher recorded, is what keeps a key from being stranded down
+        // when a modifier is tapped mid-press.
         return KeyOutcome::Pass;
     }
 
     // Windows repeats a held key by sending the press again, and the report for
-    // a key the device already holds is the one it is already reporting. Sending
-    // it changes nothing on the wire, so no echo ever comes back - and an echo
-    // that is expected but never arrives is spent on the next real press of that
-    // key instead, letting it through as the physical keyboard's. Swallowing the
-    // repeat without sending anything is both the correct answer and one less
-    // driver call inside the hook.
+    // a key the device already holds is the one it is already reporting.
+    // Sending it changes nothing on the wire, so no echo ever comes back - and
+    // an echo that is expected but never arrives is spent on the next real
+    // press of that key instead, letting it through as the physical keyboard's.
     if report == shared.keyboard {
         return KeyOutcome::AlreadyReported;
     }
@@ -418,7 +409,7 @@ fn on_key(event: KeyEvent) -> Decision {
         return Decision::PassThrough;
     }
 
-    remember_key(report, usage, event.pressed);
+    remember_key(&driver, report, usage, event.pressed);
 
     Decision::Swallow
 }
@@ -426,21 +417,26 @@ fn on_key(event: KeyEvent) -> Decision {
 /// Writes down what was just sent - or, if the redirect was switched off while
 /// the key was on its way, releases it again, so a key can never outlive the
 /// redirect that sent it.
-fn remember_key(report: KeyboardReport, usage: u8, pressed: bool) {
+///
+/// The driver is the one the report went out on, not whatever the shared state
+/// holds now: `emergency_stop` takes that field, and a key sent just before it
+/// would find nothing there to be released on.
+fn remember_key(driver: &Arc<Driver>, report: KeyboardReport, usage: u8, pressed: bool) {
     let undo = {
         let Some(mut shared) = state() else {
-            return;
+            // No state at all means the engine is being taken down around us,
+            // and the key just sent is still held.
+            return release_keyboard_without_waiting(Some(Arc::clone(driver)));
         };
 
         if shared.keyboard_enabled {
             commit_key(&mut shared, report, usage, pressed);
             None
         } else {
-            // The redirect was switched off between the send above and this
-            // point, and the switch-off already released everything it knew
-            // about. The key just sent is not among those, so it would stay
-            // held on the virtual keyboard - release it once the lock is let go.
-            shared.driver.clone()
+            // Switched off between the send above and this point. The
+            // switch-off released everything it knew about, and the key just
+            // sent is not among those.
+            Some(Arc::clone(driver))
         }
     };
 
@@ -463,9 +459,7 @@ fn decide_button(shared: &mut Shared, event: ButtonEvent) -> Option<MouseButtons
         // A button the virtual mouse is not holding - one whose press went to
         // Windows because the redirect was off, or because the driver refused
         // it - has its release go to Windows as well, in step with its press.
-        // Sending the report anyway would change nothing on the wire, so the
-        // real release would be swallowed for an event no device ever made,
-        // and the application would stay in the click it never saw end.
+        // Swallowing it would leave the application in a click it never saw end.
         return None;
     }
 
@@ -507,24 +501,23 @@ fn on_button(event: ButtonEvent) -> Decision {
         return Decision::PassThrough;
     }
 
-    remember_button(buttons, event);
+    remember_button(&driver, buttons, event);
 
     Decision::Swallow
 }
 
-fn remember_button(buttons: MouseButtons, event: ButtonEvent) {
+/// The mouse half of [`remember_key`], down to which driver the undo goes to.
+fn remember_button(driver: &Arc<Driver>, buttons: MouseButtons, event: ButtonEvent) {
     let undo = {
         let Some(mut shared) = state() else {
-            return;
+            return release_mouse_without_waiting(Some(Arc::clone(driver)));
         };
 
         if shared.mouse_enabled {
             commit_button(&mut shared, buttons, event);
             None
         } else {
-            // Switched off mid-send: release the button just sent, the same way
-            // `remember_key` releases the key just sent.
-            shared.driver.clone()
+            Some(Arc::clone(driver))
         }
     };
 
@@ -608,10 +601,10 @@ mod tests {
         assert_eq!(echo_of(&mut shared, KEY_A, true), KeyOutcome::Pass);
     }
 
-    /// The stuck-key bug this whole rule exists for: a key held while a
-    /// modifier is tapped used to have its release decided by the combo
-    /// watcher, which by then believed the key had gone to Windows - so the
-    /// virtual keyboard was never told to let go, and the key repeated forever.
+    /// The stuck-key bug this rule exists for: a key held while a modifier is
+    /// tapped used to have its release decided by the combo watcher, which by
+    /// then believed the key had gone to Windows - so the virtual keyboard was
+    /// never told to let go, and the key repeated forever.
     #[test]
     fn a_key_held_while_a_modifier_is_tapped_is_still_released_on_the_device() {
         let mut shared = session();
@@ -644,9 +637,8 @@ mod tests {
     }
 
     /// An auto-repeat would produce the very report the device is already
-    /// sending. Sending it again costs a driver call inside the hook and, worse,
-    /// records an echo that never arrives - which the next real press of that
-    /// key is then spent on.
+    /// sending, and record an echo that never arrives - which the next real
+    /// press of that key would then be spent on.
     #[test]
     fn a_repeat_of_a_held_key_sends_nothing_and_is_still_swallowed() {
         let mut shared = session();
@@ -703,7 +695,7 @@ mod tests {
 
     /// The mouse half of the stuck-key rule: a button pressed while the
     /// redirect was off reached the application, so its release has to reach
-    /// the application too - swallowing it leaves the click going forever.
+    /// the application too.
     #[test]
     fn the_release_of_a_button_the_device_never_pressed_goes_to_windows() {
         let mut shared = session();

--- a/src/redirect/mod.rs
+++ b/src/redirect/mod.rs
@@ -732,4 +732,122 @@ mod tests {
         assert_eq!(shared.stats.keystrokes, 1);
         assert_eq!(shared.stats.clicks, 1);
     }
+
+    /// A keyboard the test drives: which keys the user is really holding.
+    struct Keyboard {
+        held: [bool; 256],
+    }
+
+    impl Keyboard {
+        fn new() -> Self {
+            Self { held: [false; 256] }
+        }
+
+        /// What `hook::still_held` would answer, given this keyboard.
+        fn modifiers(&self) -> Modifiers {
+            let mut held = Modifiers::empty();
+            for usage in 0..=u8::MAX {
+                if self.held[usize::from(usage)] {
+                    if let Some(modifier) = modifier_of(usage) {
+                        held.insert(modifier);
+                    }
+                }
+            }
+            held
+        }
+
+        fn keys_down(&self) -> impl Iterator<Item = u8> + '_ {
+            (0..=u8::MAX).filter(|usage| self.held[usize::from(*usage)])
+        }
+    }
+
+    /// One event through the hook, followed by the echo the virtual device
+    /// sends back for anything that went out on the wire.
+    fn hook_event(shared: &mut Shared, keyboard: &Keyboard, usage: u8, pressed: bool) {
+        let live = keyboard.modifiers();
+        let outcome = decide_key(shared, usage, pressed, |believed| believed & live);
+
+        if let KeyOutcome::Send(report) = outcome {
+            commit_key(shared, report, usage, pressed);
+
+            // The virtual keyboard is a real HID device, so what it was just
+            // told to report comes back through the same hook.
+            assert_eq!(
+                decide_key(shared, usage, pressed, |believed| believed & live),
+                KeyOutcome::Pass,
+                "our own echo must be let through"
+            );
+        }
+    }
+
+    /// A fixed generator, so a failure is the same failure on every machine.
+    struct Rng(u64);
+
+    impl Rng {
+        fn below(&mut self, bound: u64) -> u64 {
+            self.0 = self
+                .0
+                .wrapping_mul(6_364_136_223_846_793_005)
+                .wrapping_add(1_442_695_040_888_963_407);
+
+            (self.0 >> 33) % bound
+        }
+    }
+
+    /// Letters, both sides of Ctrl, and both sides of Shift: enough for
+    /// shortcuts, repeats, and a report with no slot left.
+    const ALPHABET: [u8; 12] = [
+        0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0xE0, 0xE4, 0xE1, 0xE5,
+    ];
+
+    /// The invariant every stuck-key bug broke: nothing may be held on the
+    /// virtual keyboard once the user is holding nothing.
+    ///
+    /// Along the way the device must never hold a key the user is not holding
+    /// either - that state is what a stuck key looks like a moment before it
+    /// becomes one.
+    #[test]
+    fn no_stream_of_keys_can_leave_one_held_on_the_device() {
+        for seed in 0..256 {
+            let mut rng = Rng(seed);
+            let mut shared = session();
+            let mut keyboard = Keyboard::new();
+
+            for _ in 0..400 {
+                let usage = ALPHABET[rng.below(ALPHABET.len() as u64) as usize];
+
+                // Presses are the more common event, and repeats of a key
+                // already down are what Windows sends while it is held.
+                let pressed = rng.below(3) != 0;
+                keyboard.held[usize::from(usage)] = pressed;
+
+                hook_event(&mut shared, &keyboard, usage, pressed);
+
+                for held in 0..=u8::MAX {
+                    assert!(
+                        !shared.keyboard.holds(held) || keyboard.held[usize::from(held)],
+                        "seed {seed}: the device holds {held:#04X} and the user does not"
+                    );
+                }
+            }
+
+            // The user lets go of everything: modifiers first, the way a hand
+            // leaves a keyboard.
+            let down: Vec<u8> = keyboard.keys_down().collect();
+            for usage in down.iter().copied().filter(|u| modifier_of(*u).is_some()) {
+                keyboard.held[usize::from(usage)] = false;
+                hook_event(&mut shared, &keyboard, usage, false);
+            }
+            for usage in down.iter().copied().filter(|u| modifier_of(*u).is_none()) {
+                keyboard.held[usize::from(usage)] = false;
+                hook_event(&mut shared, &keyboard, usage, false);
+            }
+
+            assert_eq!(
+                shared.keyboard,
+                KeyboardReport::EMPTY,
+                "seed {seed}: a key was left held on the virtual keyboard"
+            );
+        }
+    }
 }

--- a/src/redirect/mod.rs
+++ b/src/redirect/mod.rs
@@ -311,13 +311,15 @@ enum KeyOutcome {
 
 /// Decides one key against everything the session knows.
 ///
-/// `live` reports the modifiers really held, and is only consulted when the
-/// watcher believes one is down - see [`ComboWatcher::press_belongs_to_shortcut`].
+/// `still_held` is handed the modifiers the watcher believes are down and
+/// answers with the ones Windows agrees about. It is only consulted when the
+/// watcher believes something is down - see
+/// [`ComboWatcher::press_belongs_to_shortcut`].
 fn decide_key(
     shared: &mut Shared,
     usage: u8,
     pressed: bool,
-    live: impl FnOnce() -> Modifiers,
+    still_held: impl FnOnce(Modifiers) -> Modifiers,
 ) -> KeyOutcome {
     // Our own virtual keyboard reports back through the same hook. Letting the
     // echo through is what keeps the two devices from feeding each other.
@@ -340,7 +342,7 @@ fn decide_key(
         // Shortcuts are left to Windows: a combination assembled from two
         // devices at once is what made them unreliable in the first place. And
         // a full report has no slot left to give.
-        if shared.combo.press_belongs_to_shortcut(live) || !report.press(usage) {
+        if shared.combo.press_belongs_to_shortcut(still_held) || !report.press(usage) {
             return KeyOutcome::Pass;
         }
     } else if report.holds(usage) {
@@ -395,7 +397,7 @@ fn on_key(event: KeyEvent) -> Decision {
         return Decision::PassThrough;
     };
 
-    let report = match decide_key(&mut shared, usage, event.pressed, hook::live_modifiers) {
+    let report = match decide_key(&mut shared, usage, event.pressed, hook::still_held) {
         KeyOutcome::Pass => return Decision::PassThrough,
         KeyOutcome::AlreadyReported => return Decision::Swallow,
         KeyOutcome::Send(report) => report,
@@ -548,7 +550,7 @@ mod tests {
     }
 
     /// Nothing is held on the real keyboard - the ordinary case.
-    fn nothing_held() -> Modifiers {
+    fn nothing_held(_believed: Modifiers) -> Modifiers {
         Modifiers::empty()
     }
 
@@ -615,7 +617,7 @@ mod tests {
         // A modifier goes down and up while the key stays held.
         press(&mut shared, LEFT_CTRL, true);
         assert_eq!(
-            decide_key(&mut shared, KEY_A, true, || Modifiers::LEFT_CTRL),
+            decide_key(&mut shared, KEY_A, true, |_| Modifiers::LEFT_CTRL),
             KeyOutcome::Pass,
             "a repeat under a modifier belongs to the shortcut"
         );

--- a/src/ui/prompt.rs
+++ b/src/ui/prompt.rs
@@ -1,9 +1,10 @@
 //! Reading the menu keys.
 //!
 //! The console is read through the raw input records rather than through a
-//! character, because the character depends on the active keyboard layout: with
-//! a Russian layout the "q" key produces a completely different letter. The
-//! scan code describes the key itself, so the menu works in any layout.
+//! character: the character depends on the active keyboard layout, the scan
+//! code describes the key itself, so the menu works in any layout.
+
+use std::time::{Duration, Instant};
 
 use windows::Win32::Foundation::{HANDLE, WAIT_OBJECT_0, WAIT_TIMEOUT};
 use windows::Win32::System::Console::{
@@ -44,10 +45,6 @@ pub const TICK_MS: u32 = 500;
 const _: () = assert!(TICK_MS > 0 && TICK_MS <= 1000);
 
 /// Waits for a menu key, or gives up after `timeout_ms` and reports a tick.
-///
-/// Keys typed while the previous command was being carried out are dropped
-/// first: a key held down for a moment used to queue up repeats, and the menu
-/// then kept toggling itself working through them.
 pub fn wait_for_command(timeout_ms: u32) -> MenuKey {
     match next_key_down(timeout_ms) {
         KeyPress::None => MenuKey::Tick,
@@ -94,12 +91,10 @@ pub fn discard_pending_keys() {
 
 /// Holds a window open that is about to take its last message with it.
 ///
-/// Started the way the program is meant to be - from Explorer, as an
-/// administrator - it gets a console window of its own, and that window dies
-/// with the process: a line printed on the way out is gone before anyone can
-/// read it. Started from a shell that was already there, or from a script, the
-/// window outlives us and stopping to ask for a key would only be in the way,
-/// so this asks who else is using the console first.
+/// Started from Explorer the program gets a console window of its own, and that
+/// window dies with the process. Started from a shell that was already there,
+/// the window outlives us and stopping to ask for a key would only be in the
+/// way - so this asks who else is using the console first.
 pub fn wait_before_the_window_closes() {
     if !owns_the_window() {
         return;
@@ -112,8 +107,7 @@ pub fn wait_before_the_window_closes() {
 /// Whether this program is the only thing attached to the console.
 fn owns_the_window() -> bool {
     // Room for two: the answer only has to tell "just us" from "somebody else
-    // as well", and asking for the whole list would mean sizing a buffer for a
-    // number that cannot change the answer.
+    // as well".
     let mut attached = [0u32; 2];
 
     // SAFETY: the list is described by the length of the buffer it is given.
@@ -146,16 +140,30 @@ enum KeyPress {
 }
 
 /// Waits for one key to go down, ignoring everything else the console reports.
+///
+/// The deadline is worked out once. Waiting `timeout_ms` again after every
+/// record we have no use for would let a mouse moving over the window put the
+/// tick off for as long as it kept moving, and the counters would stop.
 fn next_key_down(timeout_ms: u32) -> KeyPress {
-    // SAFETY: the standard input handle is owned by the process, and the buffer
-    // is one record long, which is exactly what the call is told.
+    let deadline = (timeout_ms != INFINITE)
+        .then(|| Instant::now() + Duration::from_millis(u64::from(timeout_ms)));
+
+    // SAFETY: the standard input handle is owned by the process.
     unsafe {
         let Ok(input) = GetStdHandle(STD_INPUT_HANDLE) else {
             return KeyPress::Closed;
         };
 
         loop {
-            let wait = WaitForSingleObject(input, timeout_ms);
+            let left = match deadline {
+                None => INFINITE,
+                Some(deadline) => match deadline.checked_duration_since(Instant::now()) {
+                    None => return KeyPress::None,
+                    Some(left) => milliseconds_of(left),
+                },
+            };
+
+            let wait = WaitForSingleObject(input, left);
             if wait == WAIT_TIMEOUT {
                 return KeyPress::None;
             }
@@ -165,12 +173,19 @@ fn next_key_down(timeout_ms: u32) -> KeyPress {
 
             match read_key_down(input) {
                 Ok(Some(scan_code)) => return KeyPress::ScanCode(scan_code),
-                // A mouse move or a resize: wait again.
+                // A mouse move or a resize: wait out what is left.
                 Ok(None) => {}
                 Err(()) => return KeyPress::Closed,
             }
         }
     }
+}
+
+/// A wait in milliseconds, kept below the value that means "forever".
+fn milliseconds_of(left: Duration) -> u32 {
+    u32::try_from(left.as_millis())
+        .unwrap_or(u32::MAX)
+        .min(INFINITE - 1)
 }
 
 /// Reads the one event the console is holding.
@@ -225,5 +240,23 @@ mod tests {
         for scan_code in [0x1E, 0x39, 0x3B, 0x00] {
             assert_eq!(command_for(scan_code), None, "scan code {scan_code:#04X}");
         }
+    }
+
+    /// What is left of the tick is passed on as it is.
+    #[test]
+    fn the_time_left_is_asked_for_in_milliseconds() {
+        assert_eq!(milliseconds_of(Duration::from_millis(0)), 0);
+        assert_eq!(
+            milliseconds_of(Duration::from_millis(u64::from(TICK_MS))),
+            TICK_MS
+        );
+    }
+
+    /// A wait must never come out as INFINITE by accident: that is the one
+    /// value that means the tick never arrives.
+    #[test]
+    fn a_wait_longer_than_windows_can_count_is_not_mistaken_for_forever() {
+        assert!(milliseconds_of(Duration::from_secs(60 * 60 * 24 * 365)) < INFINITE);
+        assert!(milliseconds_of(Duration::MAX) < INFINITE);
     }
 }

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -53,7 +53,7 @@ pub const ERASE_BELOW: &str = "\x1b[0J";
 pub const BLANK: &str = "\r\n";
 
 pub const TITLE: &str = "InputRedirect";
-pub const SUBTITLE: &str = "Sends your typing and your clicks through the Logitech driver";
+pub const SUBTITLE: &str = "Sends your typing and your clicks through the real signed driver";
 
 const RULE_WIDTH: usize = 58;
 const LABEL_WIDTH: usize = 20;


### PR DESCRIPTION
Implements the findings of the code audit, in the order they were prioritised.

## Why

The audit found four confirmed defects around process control and hook
lifetime, two behaviours that can leave a key held down or a redirect silently
dead, and several places where the hot path or the ownership of a Windows
handle could be tightened. Each commit fixes one of them and explains itself in
its own message.

## Confirmed defects

1. **C4** - `pnputil.exe` and `shutdown.exe` are now named by absolute path.
   Launching a system program by bare name lets anything earlier in `PATH`
   answer instead, in a process that runs elevated.
2. **C3** - the image name is checked before `TerminateProcess`. A process id
   can be reused between the lookup and the kill, so the name is the only thing
   that says the handle still refers to the intended process.
3. **C1** - if the second hook fails to install, the first one is taken down.
   Windows keeps calling a hook whose owning thread has gone until it times
   out, and the handle that could remove it was being dropped.
4. **C2** - the rollback path is handed the `Arc<Driver>` it needs, so a failed
   startup releases the virtual devices instead of leaving them plugged in.

C5 was left alone deliberately.

## Reliability

5. **H1** - the keyboard decision asks `still_held(believed)` rather than
   reading every modifier. Only the modifiers believed to be held are queried,
   which is both correct after a focus change and cheaper inside the hook.
6. **H2** - the hooks are reinstalled on a timer. Windows drops a low-level
   hook whose callback overran `LowLevelHooksTimeout` without telling anyone,
   and no call reports whether a handle is still in the chain. The replacement
   is installed before the old one is removed, so the chain is never empty.

## Hot path and ownership

7. **M1** - `EchoFilter` uses flat arrays instead of a map, so the per-event
   lookup is an index rather than a hash.
8. **M3** - `anyhow` is dropped; every error path already goes through the
   crate's own error type.
9. **M2** - `DeviceInfoSet`, process handles and the install path get RAII
   wrappers, so no early return can leak a Windows handle.
10. **L2** - paths are encoded with `encode_wide()` rather than through a lossy
    `String`, which keeps a path that is not valid Unicode intact.
11. **L4** - the menu tick tracks a deadline, so a repeated tick can no longer
    extend a wait indefinitely.
12. **L1** - `KeyboardReport::modifiers` is removed. It was never sent, and a
    field that is written but not read invites a later reader to trust it.

M4 was left alone deliberately.

## Tests

13. **T1** - a property test drives the keyboard state machine over random key
    streams and asserts no stream can leave a key held on the virtual device.
    Hand-rolled LCG rather than `proptest`, because CI builds with `--locked`
    and a new dependency would invalidate the lock file.
14. **T3** - the test that depended on how fast the machine empties the bus now
    only asserts promptness.

## Also in this branch

- The subtitle no longer names a vendor: it says the input goes through the
  real signed driver.
- `AGENTS.md` writes down how work here is submitted - small focused pull
  requests, conventional commit titles, English throughout, the three CI
  commands, and the parts of the codebase that look like oversights and are not.
- Comments were shortened throughout the files this branch touches.

## Notes for review

- `README.md` is untouched.
- Some intermediate commits split a signature change from its call sites and do
  not build on their own; the branch head does.
- Everything was checked against CI rather than a local build: `cargo fmt`,
  `cargo clippy --locked --all-targets -- -D warnings` and `cargo test` all
  pass on the branch head.