### PR TITLE
feat: ask before the driver goes on the machine

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ Compatibility section of the README.
 | ---------------- | ----------------------------------------------------------------- |
 | `src/main.rs`    | Entry point and exit codes                                        |
 | `src/error.rs`   | The crate's error type; every failure path goes through it        |
-| `src/app/`       | Startup, shutdown, single-instance guard, and the menu actions     |
+| `src/app/`       | Startup, shutdown, single-instance guard, consent, menu actions     |
 | `src/driver/`    | Driver install and removal, virtual devices, IOCTLs, the watchdog  |
 | `src/redirect/`  | The hooks, the decision made per event, echo suppression, combos   |
 | `src/hid/`       | HID report formats, modifier flags, scan code tables               |
@@ -202,8 +202,14 @@ pull request description:
 - The offset assertions in `src/driver/ioctl.rs`, which pin down the layout the
   driver expects.
 - The driver verification step in CI.
-- Installing the driver and closing G HUB without asking. Both are what the
-  program is for, and neither affects other Logitech devices.
+- Closing G HUB while the program runs. It claims the same two virtual devices,
+  and none of its own settings are affected.
+- The two questions in `src/app/consent.rs`, and the fact that `Driver::connect`
+  cannot install anything without one of them being answered. Installing a
+  kernel driver outlives the program, so it is asked for rather than assumed;
+  `SECURITY.md` and the README say the same things the screens do, and the three
+  are meant to stay in step. A start that changes nothing asks nothing, which is
+  what keeps the questions worth reading.
 
 ## Releasing
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,34 @@ and deployed on first start.
 - Windows 10 or 11
 - Administrator rights
 
+## What it does to your computer
+
+Read this once before the first run. The program asks the same question on
+screen and installs nothing until you answer it.
+
+InputRedirect cannot create a virtual keyboard or mouse by itself. It carries
+Logitech's signed driver package and installs it on first start: three kernel
+drivers, added to the Windows driver store and registered as system services.
+They were written by Logitech, not by this project.
+
+Two consequences are worth weighing before you say yes:
+
+- **Memory Integrity.** Windows may refuse to turn Core Isolation / Memory
+  Integrity on while these drivers are installed.
+- **Anti-cheat.** Protected games look for this driver by name and may refuse to
+  run alongside it - see [Compatibility](#compatibility).
+
+The driver stays installed after the window closes. `D` in the menu removes it
+again, after which the computer has to restart to finish the job.
+
+While InputRedirect is running it also keeps **Logitech G HUB closed**, because
+G HUB claims the same two virtual devices and a product id can only be claimed
+once. Profiles, macros and lighting live in G HUB's own files and are applied
+again the next time it starts.
+
+[SECURITY.md](SECURITY.md) writes all of this out as a threat model, including
+where you should not install it.
+
 ## Quick Start
 
 Run `InputRedirect.exe` as administrator and choose an option:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,147 @@
+# Security
+
+InputRedirect asks Windows to accept your typing and your clicks from a driver
+rather than from your keyboard and mouse. There is no way to do that from user
+mode, so the program carries a signed kernel driver and installs it. That single
+fact is what this document is about: it is the largest thing InputRedirect does
+to a computer, and it is larger than the program itself.
+
+Read this before the first run. The program asks the same question on screen and
+will not install anything until it is answered.
+
+## What running this program does to the machine
+
+Every one of these is done deliberately and can be read in the source.
+
+- **It requires administrator rights.** Without them it refuses to start. Not a
+  convenience: adding a driver to the driver store and creating a device node
+  cannot be done otherwise.
+- **It installs three kernel-mode drivers.** `logi_joy_bus_enum.sys`,
+  `logi_joy_xlcore.sys` and `logi_joy_vir_hid.sys`, build `2021.1.1365.0`,
+  written by Logitech and shipped with Logitech G HUB. They are embedded in the
+  executable, written out to a temporary folder and handed to `pnputil`, which
+  copies them into the Windows driver store.
+- **It registers three kernel services** under those names. They are
+  demand-start, not boot-start, but the device node they attach to persists, so
+  plug and play loads them whenever Windows enumerates it - which is every
+  start, not only while this program runs.
+- **It creates a device node**, `root\LGHUBVirtualBus`, and binds the bus driver
+  to it. The virtual keyboard and mouse are children of that node.
+- **It installs low-level input hooks** (`WH_KEYBOARD_LL`, `WH_MOUSE_LL`) for as
+  long as it runs. Every key and button on the machine passes through this
+  process while it is up.
+- **It closes Logitech G HUB** and stops `LGHUBUpdaterService` for the duration
+  of the session, and restarts them not at all - G HUB claims the same two
+  virtual devices, and a product id can only be claimed once. Profiles, macros
+  and lighting are G HUB's own files and are untouched.
+- **It writes one registry value**, `HKLM\SOFTWARE\InputRedirect\RestartPending`,
+  to remember that a removal is waiting on a reboot.
+
+Everything except the driver goes away when the program exits. The driver does
+not: it stays until it is removed, whether or not this program is ever run
+again.
+
+## What that costs you
+
+This is the part worth arguing about, and it does not depend on the quality of
+the Rust in this repository.
+
+**A program that brings its own signed kernel driver is a pattern the security
+industry has a name for: bring your own vulnerable driver.** It is not an
+accusation against these particular files. It is a description of the shape, and
+the shape has consequences whatever the driver turns out to be.
+
+- **Memory Integrity may stop working.** These driver builds are known to block
+  Core Isolation / Memory Integrity (HVCI); Logitech publishes a support note
+  about it. If you have Memory Integrity on, Windows may turn it off or refuse
+  to turn it back on while the driver is installed. That is a hardware-backed
+  kernel protection, and it is not a small thing to give up.
+- **Anti-cheat software looks for exactly this driver.** Protected games detect
+  it by name and may refuse to run. This is the documented reason InputRedirect
+  does not work in some games.
+- **A blocklist entry would end it.** If Microsoft adds these builds to the
+  Vulnerable Driver Blocklist, Windows stops loading them and the program stops
+  working entirely. Nothing in this repository can prevent that.
+- **The attack surface of the machine grows.** Three more drivers in the kernel
+  are three more drivers in the kernel. Any weakness in them is reachable on
+  your machine once they are installed, by anything running on it, not only by
+  this program.
+- **Reports of bugchecks exist.** These drivers appear in third-party reports of
+  `HIDCLASS.SYS` bugchecks. Not reproduced here; recorded because it would be
+  dishonest to leave it out.
+
+## Where not to run this
+
+Do not install it on a machine you do not own outright, or on one where the
+consequences above are somebody else's to accept:
+
+- managed or corporate machines, including anything joined to a domain or
+  enrolled in Intune;
+- machines that have to stay compliant with a hardening baseline, or where
+  Memory Integrity, Credential Guard or an EDR agent is a requirement rather
+  than a default;
+- shared machines, and machines used by anyone who has not read this page;
+- anything where a blocked driver, a failed anti-cheat check or an unexplained
+  bugcheck would matter.
+
+InputRedirect is a tool for a machine its owner is willing to experiment on.
+It is not enterprise software and is not built to be.
+
+## What the program does not do
+
+Stated because "it installs a kernel driver" invites worse guesses:
+
+- **No network access.** The program makes no outbound connections, has no
+  update check and sends no telemetry. Its whole dependency list is `bitflags`,
+  `tempfile`, `thiserror`, `windows` and `embed-resource`, none of which speaks
+  to the network.
+- **No keystroke logging.** Input passes through the hooks and is forwarded to
+  the virtual device. Nothing is written to disk and nothing is kept beyond the
+  two counters on screen.
+- **No autostart, no service of its own, no scheduled task.** Closing the window
+  ends it. The only thing that survives is the driver.
+- **No modification of the driver bytes.** The files are embedded verbatim,
+  because a single changed byte would break the signature in the catalogue and
+  Windows would refuse to load them.
+
+## Supply chain
+
+The driver files in `drivers/` are Logitech's, unmodified. CI checks, on every
+push and on every release:
+
+- the folder holds exactly the seven expected files;
+- each catalogue carries a valid Authenticode signature from the Windows
+  Hardware Compatibility Publisher, which is how a kernel driver on x64 is
+  signed - the vendor submits the package and Microsoft signs it, so the signer
+  never names the vendor;
+- each `.inf` names Logitech as the vendor, which is where the ownership of the
+  package is actually stated;
+- `cargo audit` reads `Cargo.lock` against the RustSec advisory database.
+
+CI also prints the SHA-256 of each driver file. Those hashes are printed rather
+than compared against a recorded list, so a change to them is visible in a run
+log but is not yet enforced by a check.
+
+## Removing everything
+
+Press `D` in the menu. The program unplugs the virtual devices, stops the
+services, deletes both packages from the driver store and offers a restart.
+**The restart is not optional:** until it happens Windows keeps the old driver
+images loaded, so the removal is only half done and the program cannot work.
+After the restart the machine is in the state it was in before the first run.
+
+If the removal fails, the program names the processes holding the driver files
+open. That is usually G HUB or the kernel itself, and a restart followed by an
+immediate second attempt is the answer.
+
+## Reporting a vulnerability
+
+Open a [security advisory](https://github.com/kerogenesis/InputRedirect/security/advisories/new)
+rather than a public issue. Useful things to include: the Windows build, whether
+Memory Integrity was on, and which of the steps above the machine got to.
+
+Two classes of report will be closed as working as intended, because they are
+this program's design and are documented above: that it installs a third-party
+kernel driver, and that it hooks all keyboard and mouse input while it runs. A
+report that one of those does something beyond what this page describes is very
+much wanted.

--- a/src/app/consent.rs
+++ b/src/app/consent.rs
@@ -1,0 +1,231 @@
+//! Asking before the driver goes on the machine.
+//!
+//! Removing the driver has always explained itself and waited for a yes.
+//! Installing it did not, and it is the less reversible of the two: the package
+//! stays in the driver store after this window closes, protected games look for
+//! exactly this driver, and on some machines Windows will not turn Memory
+//! Integrity on while it is installed.
+//!
+//! Both screens are built the same way the removal screen is - a headline, a
+//! block of plain sentences, then a question - because a user who has read one
+//! of them should recognise the shape of the other.
+
+use crate::driver::{Consent, Mismatch, Version};
+use crate::ui::{self, Screen, Tone};
+
+const ABOUT_TO_INSTALL: &str = "About to install the Logitech driver on this computer";
+
+const INSTALL_NOTES: [&str; 13] = [
+    "This program cannot create a virtual keyboard or mouse by",
+    "itself. It carries Logitech's signed driver package and",
+    "installs it: three kernel drivers, added to the Windows",
+    "driver store and started as system services.",
+    "",
+    "They were written by Logitech, not by this project, and two",
+    "things follow from that. Windows may refuse to turn Memory",
+    "Integrity on while they are installed, and anti-cheat",
+    "software looks for this driver by name.",
+    "",
+    "The driver stays on this computer after the window closes.",
+    "Press D in the menu to remove it again; the computer then",
+    "has to restart to finish the job.",
+];
+
+const INSTALL_QUESTION: &str = "Install the driver?";
+
+const ABOUT_TO_REPLACE: &str = "A different build of the Logitech driver is installed";
+
+const REPLACE_NOTES: [&str; 12] = [
+    "The requests this program sends were read out of one build",
+    "of the driver. Another build answers them with nothing more",
+    "than \"invalid parameter\", so the installed one has to go and",
+    "ours has to take its place.",
+    "",
+    "Whatever put that build there - Logitech G HUB, or a driver",
+    "update - was using it, and may not work properly again until",
+    "it installs its own.",
+    "",
+    "Pressing D in the menu removes our driver, but it does not",
+    "bring the other build back. Only the software that owns it",
+    "can do that.",
+];
+
+const REPLACE_QUESTION: &str = "Replace the installed driver?";
+
+const ANSWERS: &str = "Y = yes, N = no";
+
+/// Puts the questions on the screen the program is already drawing to.
+pub struct Ask<'a> {
+    screen: &'a Screen,
+}
+
+impl<'a> Ask<'a> {
+    pub fn on(screen: &'a Screen) -> Self {
+        Self { screen }
+    }
+
+    /// The part both screens end with.
+    fn notes_then_question(&self, notes: &[&str], question: &str) -> bool {
+        for note in notes {
+            self.screen.note(note);
+        }
+
+        self.screen.blank();
+        self.screen.ask(question, ANSWERS);
+
+        ui::confirm()
+    }
+}
+
+impl Consent for Ask<'_> {
+    fn allow_install(&mut self) -> bool {
+        self.screen.begin_screen();
+        self.screen.report(Tone::Warning, ABOUT_TO_INSTALL);
+        self.screen.blank();
+
+        self.notes_then_question(&INSTALL_NOTES, INSTALL_QUESTION)
+    }
+
+    fn allow_replacement(&mut self, mismatch: Mismatch) -> bool {
+        self.screen.begin_screen();
+        self.screen.report(Tone::Warning, ABOUT_TO_REPLACE);
+        self.screen.blank();
+
+        // The two builds are what there is to weigh here, so they are named
+        // above the explanation rather than left inside it.
+        for line in builds(mismatch.installed, mismatch.ours) {
+            self.screen.note(&line);
+        }
+        self.screen.blank();
+
+        self.notes_then_question(&REPLACE_NOTES, REPLACE_QUESTION)
+    }
+}
+
+/// Which build is on the machine and which one would take its place.
+///
+/// Two lines rather than one sentence: on one line the two version numbers sit
+/// next to each other and the reader has to work out which is which.
+fn builds(installed: Version, ours: Version) -> [String; 2] {
+    [
+        format!("Installed on this computer:  {installed}"),
+        format!("The build this program speaks to:  {ours}"),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The widest a line may be. The status block draws a rule of 58 columns
+    /// from the second, and a note is indented by four, so a line longer than
+    /// this wraps and the block stops reading as a block.
+    const WIDTH: usize = 60;
+
+    /// A machine carrying a 2024 build, against the one this program speaks to.
+    fn mismatch() -> Mismatch {
+        Mismatch {
+            installed: Version::from_words(0x07e8_0001, 0),
+            ours: Version::from_words(0x07e5_0001, 0x0555_0000),
+        }
+    }
+
+    fn install_screen() -> String {
+        INSTALL_NOTES.join(" ")
+    }
+
+    fn replace_screen() -> String {
+        REPLACE_NOTES.join(" ")
+    }
+
+    /// A note that wraps breaks the block it belongs to, and these are the two
+    /// longest blocks in the program.
+    #[test]
+    fn every_line_of_both_screens_fits_the_console_layout() {
+        for note in INSTALL_NOTES.iter().chain(REPLACE_NOTES.iter()) {
+            assert!(
+                note.chars().count() <= WIDTH,
+                "{note:?} is {} columns wide",
+                note.chars().count()
+            );
+        }
+
+        for headline in [ABOUT_TO_INSTALL, ABOUT_TO_REPLACE] {
+            assert!(headline.chars().count() <= WIDTH, "{headline:?}");
+        }
+    }
+
+    /// The whole reason this screen exists. A rewording that quietly dropped one
+    /// of these would put the program back where it started.
+    #[test]
+    fn the_installation_screen_says_what_the_driver_is_and_what_it_costs() {
+        let screen = install_screen();
+
+        for said in ["kernel", "Logitech", "Memory Integrity", "anti-cheat"] {
+            assert!(
+                screen.contains(said),
+                "the screen does not mention {said:?}"
+            );
+        }
+    }
+
+    /// A user who agrees has to know how to change their mind afterwards.
+    #[test]
+    fn the_installation_screen_says_how_to_undo_it() {
+        let screen = install_screen();
+
+        assert!(screen.contains("Press D in the menu to remove it again"));
+        assert!(screen.contains("restart"));
+    }
+
+    /// Replacing somebody else's working installation is a different question
+    /// from installing into an empty one, and it is asked as one.
+    #[test]
+    fn the_replacement_screen_is_about_the_installation_it_would_overwrite() {
+        let screen = replace_screen();
+
+        assert!(screen.contains("G HUB"));
+        assert!(
+            screen.contains("does not bring the other build back"),
+            "the screen has to say that D will not bring the other build back"
+        );
+    }
+
+    /// "Replacing the driver" is a sentence a user can only wonder about; the
+    /// two versions are what they can quote in a question.
+    #[test]
+    fn the_replacement_screen_names_both_builds() {
+        let broken = mismatch();
+        let [installed, ours] = builds(broken.installed, broken.ours);
+
+        assert!(
+            installed.contains("2024.1.0.0"),
+            "{installed:?} hides what is there"
+        );
+        assert!(
+            ours.contains("2021.1.1365.0"),
+            "{ours:?} hides what we speak"
+        );
+    }
+
+    /// The version numbers are read from the files, so the widest one Windows
+    /// can report has to fit as well as the one this program ships with.
+    #[test]
+    fn the_widest_version_windows_could_report_still_fits_the_layout() {
+        let widest = Version::from_words(u32::MAX, u32::MAX);
+
+        for line in builds(widest, widest) {
+            assert!(line.chars().count() <= WIDTH, "{line:?}");
+        }
+    }
+
+    /// Both questions have to be answerable with the keys the prompt offers.
+    #[test]
+    fn both_questions_offer_the_same_two_answers() {
+        assert!(ANSWERS.contains('Y') && ANSWERS.contains('N'));
+
+        for question in [INSTALL_QUESTION, REPLACE_QUESTION] {
+            assert!(question.ends_with('?'), "{question:?}");
+        }
+    }
+}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,6 +1,7 @@
 //! The program as the user experiences it: a screen, a menu and a loop.
 
 mod actions;
+mod consent;
 mod exit;
 mod instance;
 
@@ -105,14 +106,17 @@ impl App {
         // The setup lines scroll past as they happen, so a slow first
         // installation does not look like a frozen program.
         let screen = &self.screen;
-        let driver = Driver::connect(&mut |step: Step| {
-            let tone = if step == Step::InstallingDriver {
-                Tone::Working
-            } else {
-                Tone::Done
-            };
-            screen.report(tone, &step.to_string());
-        })?;
+        let driver = Driver::connect(
+            &mut |step: Step| {
+                let tone = if step == Step::InstallingDriver {
+                    Tone::Working
+                } else {
+                    Tone::Done
+                };
+                screen.report(tone, &step.to_string());
+            },
+            &mut consent::Ask::on(screen),
+        )?;
 
         let driver = Arc::new(driver);
         self.engine = Some(Engine::install(Arc::clone(&driver))?);

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -19,6 +19,7 @@ pub use payload::ExtractedDrivers;
 pub use reboot::{
     clear_restart_pending, is_restart_pending, mark_restart_pending, request_restart,
 };
+pub use version::{Mismatch, Version};
 
 use std::borrow::Cow;
 use std::ffi::OsString;
@@ -59,7 +60,7 @@ pub enum Step {
     InstallingDriver,
     /// Carries both builds: replacing someone's driver is worth reading the
     /// details of.
-    ReplacingDriver(version::Mismatch),
+    ReplacingDriver(Mismatch),
     DriverReady,
     CleaningPreviousSession,
     RebuildingBus,
@@ -111,6 +112,73 @@ impl<F: FnMut(Step)> Report for F {
     }
 }
 
+/// Who is asked before the driver package on this machine is changed.
+///
+/// Installing a kernel driver is not something a program does on the way to
+/// doing what it was started for. It outlives the window: the package stays in
+/// the driver store, the services stay registered, anti-cheat software looks
+/// for exactly this driver, and on some machines Windows will not turn Memory
+/// Integrity on while it is installed. Removal has always explained itself and
+/// waited for an answer, and installation is the less reversible of the two.
+///
+/// The questions live here rather than in the interface so that the driver layer
+/// cannot install anything without one being answered first.
+pub trait Consent {
+    /// Asked before the driver is installed on a machine that does not have it.
+    fn allow_install(&mut self) -> bool;
+
+    /// Asked before another build of the same driver is replaced with ours,
+    /// which is a change to an installation somebody else is using.
+    fn allow_replacement(&mut self, mismatch: Mismatch) -> bool;
+}
+
+/// What has to happen to the driver package before this program can talk to it.
+///
+/// Worked out before anything on the machine is touched. Two of the three
+/// answers are changes the user has to agree to, and a refusal has to leave the
+/// machine exactly as it was found - which includes G HUB, closed for the rest
+/// of the session by the watchdog that would otherwise already be running.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Plan {
+    /// The build this program speaks to is already installed. Nothing to agree
+    /// to, and nothing to ask about on every start.
+    AlreadyInstalled,
+    /// Nothing of this driver is on the machine.
+    Install,
+    /// Another build is installed, and it belongs to whoever put it there.
+    Replace(Mismatch),
+}
+
+/// Decides what the machine needs, without changing it.
+///
+/// A build we did not read the protocol out of answers with an invalid
+/// parameter and no reason - the same thing it says when a device is merely
+/// busy. A protocol is not a version number to be compared for greatness, so
+/// ours goes in whichever way the two differ.
+fn plan_for(bundled: &Path) -> Plan {
+    if !service::driver_installed() {
+        return Plan::Install;
+    }
+
+    match version::mismatch(bundled) {
+        None => Plan::AlreadyInstalled,
+        Some(mismatch) => Plan::Replace(mismatch),
+    }
+}
+
+/// Whether the plan may go ahead, asking only where the machine would change.
+///
+/// A start that changes nothing asks nothing. A question on every start would
+/// teach the user to answer it without reading, which is the outcome this whole
+/// exchange exists to avoid.
+fn approved(plan: Plan, consent: &mut dyn Consent) -> bool {
+    match plan {
+        Plan::AlreadyInstalled => true,
+        Plan::Install => consent.allow_install(),
+        Plan::Replace(mismatch) => consent.allow_replacement(mismatch),
+    }
+}
+
 /// What the interface shows in its status line.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct Status {
@@ -143,13 +211,25 @@ pub struct Driver {
 impl Driver {
     /// Installs the driver if it is missing, then opens it and creates the two
     /// virtual devices.
-    pub fn connect(report: &mut dyn Report) -> Result<Self> {
+    ///
+    /// Nothing is installed without `consent` agreeing to it first, and a
+    /// refusal is [`Error::Refused`] rather than a failure: the machine is left
+    /// as it was found.
+    pub fn connect(report: &mut dyn Report, consent: &mut dyn Consent) -> Result<Self> {
         if !is_elevated() {
             return Err(Error::NotElevated);
         }
 
         report.step(Step::PreparingFiles);
         let payload = ExtractedDrivers::unpack()?;
+
+        // Asked before the first thing that cannot be taken back. The extracted
+        // files go with the payload when it drops, so a refusal here really does
+        // leave nothing behind.
+        let plan = plan_for(payload.directory());
+        if !approved(plan, consent) {
+            return Err(Error::Refused);
+        }
 
         // G HUB takes the very product ids we ask for, and a product id can
         // only be taken once. Its agent starts itself again a moment after it
@@ -160,31 +240,26 @@ impl Driver {
         }
         let watchdog = ghub::Watchdog::start();
 
-        if service::driver_installed() {
-            // A build we did not read the protocol out of answers with an
-            // invalid parameter and no reason - the same thing it says when a
-            // device is merely busy. A protocol is not a version number to be
-            // compared for greatness, so ours goes in whichever way they differ.
-            match version::mismatch(payload.directory()) {
-                None => {
-                    report.step(Step::DriverReady);
+        match plan {
+            Plan::AlreadyInstalled => {
+                report.step(Step::DriverReady);
 
-                    // Re-binding on every start is not optional: without it the
-                    // first plug after a service restart fails with an invalid
-                    // parameter, because the bus keeps stale state. A fresh
-                    // install does this on its way through.
-                    install::bind_root_device(payload.directory())?;
-                }
-                Some(mismatch) => {
-                    report.step(Step::ReplacingDriver(mismatch));
-                    install::replace(payload.directory())?;
-                    report.step(Step::DriverReady);
-                }
+                // Re-binding on every start is not optional: without it the
+                // first plug after a service restart fails with an invalid
+                // parameter, because the bus keeps stale state. A fresh install
+                // does this on its way through.
+                install::bind_root_device(payload.directory())?;
             }
-        } else {
-            report.step(Step::InstallingDriver);
-            install::install(payload.directory())?;
-            report.step(Step::DriverReady);
+            Plan::Replace(mismatch) => {
+                report.step(Step::ReplacingDriver(mismatch));
+                install::replace(payload.directory())?;
+                report.step(Step::DriverReady);
+            }
+            Plan::Install => {
+                report.step(Step::InstallingDriver);
+                install::install(payload.directory())?;
+                report.step(Step::DriverReady);
+            }
         }
 
         service::start_all();
@@ -663,11 +738,75 @@ mod tests {
     }
 
     /// A machine carrying a 2024 build, against the one this program speaks to.
-    fn mismatch() -> version::Mismatch {
-        version::Mismatch {
-            installed: version::Version::from_words(0x07e8_0001, 0),
-            ours: version::Version::from_words(0x07e5_0001, 0x0555_0000),
+    fn mismatch() -> Mismatch {
+        Mismatch {
+            installed: Version::from_words(0x07e8_0001, 0),
+            ours: Version::from_words(0x07e5_0001, 0x0555_0000),
         }
+    }
+
+    /// An answer decided in advance, which also writes down what it was asked.
+    /// Which question arrives matters as much as the answer: the two screens say
+    /// different things, and the wrong one would ask the user to agree to
+    /// something other than what is about to happen.
+    struct Answer {
+        yes: bool,
+        asked: Vec<&'static str>,
+    }
+
+    impl Answer {
+        fn of(yes: bool) -> Self {
+            Self {
+                yes,
+                asked: Vec::new(),
+            }
+        }
+    }
+
+    impl Consent for Answer {
+        fn allow_install(&mut self) -> bool {
+            self.asked.push("install");
+            self.yes
+        }
+
+        fn allow_replacement(&mut self, _mismatch: Mismatch) -> bool {
+            self.asked.push("replacement");
+            self.yes
+        }
+    }
+
+    /// The common case, and the one that must stay silent: a user who agreed
+    /// once and starts the program every day is not asked again.
+    #[test]
+    fn a_start_that_changes_nothing_asks_nothing() {
+        let mut answer = Answer::of(false);
+
+        assert!(approved(Plan::AlreadyInstalled, &mut answer));
+        assert!(answer.asked.is_empty(), "{:?}", answer.asked);
+    }
+
+    #[test]
+    fn the_driver_is_not_installed_without_a_yes() {
+        let mut refused = Answer::of(false);
+        assert!(!approved(Plan::Install, &mut refused));
+        assert_eq!(refused.asked, ["install"]);
+
+        let mut agreed = Answer::of(true);
+        assert!(approved(Plan::Install, &mut agreed));
+        assert_eq!(agreed.asked, ["install"]);
+    }
+
+    /// Overwriting a build somebody else installed is its own question, not the
+    /// installation one asked again.
+    #[test]
+    fn replacing_another_build_is_asked_about_in_its_own_words() {
+        let mut refused = Answer::of(false);
+        assert!(!approved(Plan::Replace(mismatch()), &mut refused));
+        assert_eq!(refused.asked, ["replacement"]);
+
+        let mut agreed = Answer::of(true);
+        assert!(approved(Plan::Replace(mismatch()), &mut agreed));
+        assert_eq!(agreed.asked, ["replacement"]);
     }
 
     #[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,6 +22,12 @@ pub enum Error {
     #[error("another copy of InputRedirect is already running")]
     AlreadyRunning,
 
+    /// The driver had to be installed or replaced, the user was asked, and the
+    /// answer was no. Nothing went wrong and nothing was changed, which is why
+    /// the sentence does not read like a failure.
+    #[error("the Logitech driver was not installed")]
+    Refused,
+
     #[error("the driver files could not be prepared: {0}")]
     Payload(String),
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ const EXIT_NOT_ELEVATED: u8 = 1;
 const EXIT_FAILED: u8 = 2;
 const EXIT_RESTART_REQUIRED: u8 = 3;
 const EXIT_ALREADY_RUNNING: u8 = 4;
+const EXIT_DECLINED: u8 = 5;
 
 fn main() -> ExitCode {
     match App::new().run() {
@@ -42,6 +43,14 @@ fn give_up(error: &Error) -> ExitCode {
             eprintln!("InputRedirect is already running in another window.");
             eprintln!("Switch to that window, or close it before starting again.");
             EXIT_ALREADY_RUNNING
+        }
+        // Not a failure, and it must not read like one: the user was asked and
+        // said no, so the only thing left to confirm is that saying no cost
+        // them nothing.
+        Error::Refused => {
+            eprintln!("InputRedirect cannot redirect anything without the Logitech driver.");
+            eprintln!("Nothing on this computer was changed.");
+            EXIT_DECLINED
         }
         Error::RestartRequired(reason) => {
             eprintln!("InputRedirect cannot start yet: {reason}.");


### PR DESCRIPTION
Closes **S1** from the audit, the one item it marked as mandatory. Follows on from #4, which took the rest of that list.

## The asymmetry

Removing the driver showed an eight-line explanation and waited for a `Y`. Installing it happened in silence, on the way to doing what the program was started for — and it is the less reversible of the two. The package stays in the driver store after the window closes, three kernel services stay registered, protected games look for exactly this driver, and on some machines Windows will not turn Memory Integrity back on while it is there.

`install::replace` was quieter still. It fires when a *different* build of the same driver is installed, which in practice means the user has G HUB and uses it, and it overwrote that working installation without a word.

## The change

`Driver::connect` decided and acted in the same breath: `service::driver_installed()` was both the question and the branch that installed. There was no moment at which anything could be asked, because there was no representation of "here is what I am about to do".

So deciding is now separate from doing:

```rust
enum Plan {
    AlreadyInstalled,     // our build is there; nothing to agree to
    Install,              // nothing of this driver is on the machine
    Replace(Mismatch),    // another build is there, and it belongs to someone
}

fn approved(plan: Plan, consent: &mut dyn Consent) -> bool {
    match plan {
        Plan::AlreadyInstalled => true,
        Plan::Install => consent.allow_install(),
        Plan::Replace(mismatch) => consent.allow_replacement(mismatch),
    }
}
```

`connect` now takes `&mut dyn Consent` alongside `&mut dyn Report`, so the install path cannot be reached without something that can be asked — checked by the compiler rather than by review. Two methods rather than one `allow(change)`, because the two screens make different arguments and only the replacement screen has to admit that `D` will not bring the other build back.

**`AlreadyInstalled` asks nothing.** A user who agreed once and starts the program every day is not asked again; a prompt on every start is one nobody reads, which would manufacture the appearance of consent while destroying the substance. Pinned by a test.

### Where the question sits

Ordering carries the weight. Asking before unpacking is not possible — telling `Install` from `Replace` needs the version out of our bundled `.sys` files, which are not files until then. Asking just before `install::install` would have been too late: `ghub::stop()` and the watchdog come first, so a declining user would have had their G HUB killed anyway.

```
unpack payload → decide the Plan → ASK → close G HUB → install
                                    │
                                    └─ no ──▶ payload drops, temp folder gone,
                                              G HUB untouched, Error::Refused
```

A no is `Error::Refused` and exit code `5`, not a failure — the message's second line is "Nothing on this computer was changed."

### Screens, and the docs that have to agree with them

`src/app/consent.rs`, next to the removal screen it is modelled on rather than inside the driver layer. Same shape — headline, plain sentences, question — so a user who has read one recognises the other. The install screen names the four things that cost something: kernel drivers, Logitech's authorship, Memory Integrity, anti-cheat, plus how to undo it.

`SECURITY.md` states the threat model rather than leaving it to be inferred: every persistent change a run makes, what the bring-your-own-driver shape costs whatever the files turn out to be, where the program should not be installed, and — because "it installs a kernel driver" invites worse guesses — what it demonstrably does not do (no network, no logging, no autostart). It also records that CI prints the driver hashes without comparing them to anything, which is a gap and should read as one.

`README.md` gains the short version above Quick Start, so it is read before the download.

`CONTRIBUTING.md` needed a correction that matters as much as the code. **Things to leave alone** previously read *"Installing the driver and closing G HUB without asking. Both are what the program is for"* — a written-down invariant that this change inverts, and one that would have told a future contributor the silence was deliberate. The G HUB half is still true and stays; the install half is now the opposite.

## Verification

**CI on this branch is green.** That includes `cargo test --locked --all-targets` on `windows-latest`, so all ten new tests ran on Windows, not only in the workaround below.

Locally, `cargo fmt --all --check` and `cargo clippy --target x86_64-pc-windows-msvc --locked --all-targets -- -D warnings` both pass clean.

`cargo test` cannot **link** off Windows — `lld-link` is present but there is no SDK, so `kernel32.lib` and friends are missing. To avoid pushing tests that had only been compiled, the pure logic was first extracted programmatically (exact text, not retyped) into a scratch crate built for Linux: `Plan`/`Consent`/`approved`, `Version`/`Mismatch`, the note constants, `builds`, and all ten tests. 10 passed, 0 failed — later confirmed by CI on the real target.

Then five mutations were injected one at a time, each caught by exactly one test — so these are tests with teeth, not tests that merely pass:

| Mutation | Test that failed |
| --- | --- |
| `AlreadyInstalled` asks the install question anyway | `a_start_that_changes_nothing_asks_nothing` |
| `Replace` routed to `allow_install` instead | `replacing_another_build_is_asked_about_in_its_own_words` |
| "Memory Integrity" quietly reworded out of the notes | `the_installation_screen_says_what_the_driver_is_and_what_it_costs` |
| A note grown past the console width | `every_line_of_both_screens_fits_the_console_layout` |
| The "press D to remove" instruction dropped | `the_installation_screen_says_how_to_undo_it` |

### Still unverified — needs a real machine

No test and no CI job can install a driver, so the parts that only a human at a Windows console can confirm: that the confirmation screen renders inside one console window without scrolling; that `ui::confirm()` reads `Y`/`N` correctly at this point in startup; that a refusal really leaves G HUB running; and the whole `Replace` path, which additionally needs a machine carrying a different Logitech driver build.

The explainer doc has a step-by-step manual QA script for all five cases, including the one worth checking by hand: that the **second** start asks nothing.

## Deliberately not here

Follow-ups from the audit, each its own concern: `drivers/SHA256SUMS` with the hashes compared rather than printed (S3 — CI now prints values a list could be built from), `bytemuck::Pod` for the packed requests (S8 — there is already a `refactor/checked-byte-conversions` branch for this, currently based on the pre-merge #4 branch), full-path comparison when closing G HUB (S5), the driver temp folder under the system temp (S6), where the driver protocol was read from (O3), `windows-registry` in place of the hand-written registry code, and an optional log file.

---

📄 [Explainer: S1 — Consent before the kernel driver is installed](https://app.notion.com/p/3adaf11124bd81cdafe6d6732de2aef2)

🛡️ [Audit: InputRedirect — security, Rust code quality, onboarding](https://app.notion.com/p/d1cb88902f764170aaf4ed7aa7b84f2a)
