### PR TITLE
refactor: let the compiler check the request layouts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+
+# Dependabot only opens the pull request. Each one still goes through CI, which
+# builds with --locked, so a bump that forgot Cargo.lock fails there rather than
+# on a maintainer's machine.
+updates:
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: chore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,13 @@ jobs:
 
       # These files are installed into the system driver store, so this is the
       # step that decides what a user ends up running in the kernel: the package
-      # has to be complete, validly signed, and signed by Logitech. A valid
-      # signature on its own says nothing about who produced the file.
+      # has to be complete, it has to carry the signature Windows requires of a
+      # kernel driver, and it has to be Logitech's package.
+      #
+      # Those are two separate questions. A kernel driver on x64 cannot be
+      # signed by its vendor - the vendor submits it and Microsoft signs the
+      # catalogue - so the signer says nothing about who wrote it, and the
+      # vendor is stated in the INF.
       - name: Verify the signed driver files
         shell: pwsh
         run: |
@@ -71,8 +76,15 @@ jobs:
             if ($signature.Status -ne 'Valid') {
               throw "$($catalog.Name) is not validly signed: $($signature.Status)"
             }
-            if ($subject -notmatch 'Logitech') {
-              throw "$($catalog.Name) is signed by $subject, not by Logitech"
+            if ($subject -notmatch 'Windows Hardware Compatibility Publisher') {
+              throw "$($catalog.Name) is signed by $subject, not through the WHQL programme"
+            }
+          }
+
+          foreach ($inf in Get-ChildItem drivers -Filter *.inf) {
+            $text = Get-Content $inf.FullName -Raw
+            if ($text -notmatch '(?im)^\s*Vendor\s*=\s*"Logitech"') {
+              throw "$($inf.Name) does not name Logitech as the vendor"
             }
           }
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,19 +39,48 @@ jobs:
           key: cargo-${{ runner.os }}-${{ steps.toolchain.outputs.version }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}
           restore-keys: cargo-${{ runner.os }}-${{ steps.toolchain.outputs.version }}-
 
+      # These files are installed into the system driver store, so this is the
+      # step that decides what a user ends up running in the kernel: the package
+      # has to be complete, validly signed, and signed by Logitech. A valid
+      # signature on its own says nothing about who produced the file.
       - name: Verify the signed driver files
         shell: pwsh
         run: |
-          Get-ChildItem drivers | ForEach-Object {
-            $hash = (Get-FileHash $_.FullName -Algorithm SHA256).Hash
-            Write-Host "$($_.Name)  $hash"
+          $expected = @(
+            'logi_joy_bus_enum.cat',
+            'logi_joy_bus_enum.inf',
+            'logi_joy_bus_enum.sys',
+            'logi_joy_vir_hid.cat',
+            'logi_joy_vir_hid.inf',
+            'logi_joy_vir_hid.sys',
+            'logi_joy_xlcore.sys'
+          )
+          $present = @(Get-ChildItem drivers -File | ForEach-Object { $_.Name } | Sort-Object)
+
+          $difference = Compare-Object $expected $present
+          if ($difference) {
+            $names = ($difference | ForEach-Object { $_.InputObject }) -join ', '
+            throw "drivers/ is not the expected package, it differs in: $names"
           }
-          Get-ChildItem drivers -Filter *.cat | ForEach-Object {
-            $signature = Get-AuthenticodeSignature $_.FullName
-            Write-Host "$($_.Name): $($signature.Status) - $($signature.SignerCertificate.Subject)"
+
+          foreach ($catalog in Get-ChildItem drivers -Filter *.cat) {
+            $signature = Get-AuthenticodeSignature $catalog.FullName
+            $subject = $signature.SignerCertificate.Subject
+            Write-Host "$($catalog.Name): $($signature.Status) - $subject"
+
             if ($signature.Status -ne 'Valid') {
-              throw "$($_.Name) is not validly signed: $($signature.Status)"
+              throw "$($catalog.Name) is not validly signed: $($signature.Status)"
             }
+            if ($subject -notmatch 'Logitech') {
+              throw "$($catalog.Name) is signed by $subject, not by Logitech"
+            }
+          }
+
+          # Printed, not compared: nothing in the repository records what the
+          # hashes are meant to be. A change to these lines in a pull request
+          # diff is a change to the bytes that get installed.
+          Get-ChildItem drivers -File | ForEach-Object {
+            "$((Get-FileHash $_.FullName -Algorithm SHA256).Hash.ToLower())  $($_.Name)"
           }
 
       # Fails when Cargo.toml and Cargo.lock disagree, which is worth saying in
@@ -112,3 +141,23 @@ jobs:
           name: InputRedirect
           path: dist/InputRedirect.exe
           if-no-files-found: error
+
+  # An advisory against a crate this program links into an elevated process is
+  # worth hearing about on the push that introduced it. The job reads Cargo.lock
+  # rather than building, so it needs neither Windows nor the toolchain cache.
+  audit:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      checks: write
+      issues: write
+
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4
+
+      - name: Audit the dependencies
+        uses: rustsec/audit-check@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,8 @@ jobs:
 
       # The checks repeated here are the ones that decide whether the artifact
       # is fit to publish. Formatting and lints are CI's job: they say nothing
-      # about the bytes that ship. This one is kept in step with ci.yml.
+      # about the bytes that ship. This one is kept in step with ci.yml, see
+      # there for why the signer and the vendor are two separate questions.
       - name: Verify the signed driver files
         shell: pwsh
         run: |
@@ -94,8 +95,15 @@ jobs:
             if ($signature.Status -ne 'Valid') {
               throw "$($catalog.Name) is not validly signed: $($signature.Status)"
             }
-            if ($subject -notmatch 'Logitech') {
-              throw "$($catalog.Name) is signed by $subject, not by Logitech"
+            if ($subject -notmatch 'Windows Hardware Compatibility Publisher') {
+              throw "$($catalog.Name) is signed by $subject, not through the WHQL programme"
+            }
+          }
+
+          foreach ($inf in Get-ChildItem drivers -Filter *.inf) {
+            $text = Get-Content $inf.FullName -Raw
+            if ($text -notmatch '(?im)^\s*Vendor\s*=\s*"Logitech"') {
+              throw "$($inf.Name) does not name Logitech as the vendor"
             }
           }
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,15 +65,37 @@ jobs:
 
       # The checks repeated here are the ones that decide whether the artifact
       # is fit to publish. Formatting and lints are CI's job: they say nothing
-      # about the bytes that ship.
+      # about the bytes that ship. This one is kept in step with ci.yml.
       - name: Verify the signed driver files
         shell: pwsh
         run: |
-          Get-ChildItem drivers -Filter *.cat | ForEach-Object {
-            $signature = Get-AuthenticodeSignature $_.FullName
-            Write-Host "$($_.Name): $($signature.Status) - $($signature.SignerCertificate.Subject)"
+          $expected = @(
+            'logi_joy_bus_enum.cat',
+            'logi_joy_bus_enum.inf',
+            'logi_joy_bus_enum.sys',
+            'logi_joy_vir_hid.cat',
+            'logi_joy_vir_hid.inf',
+            'logi_joy_vir_hid.sys',
+            'logi_joy_xlcore.sys'
+          )
+          $present = @(Get-ChildItem drivers -File | ForEach-Object { $_.Name } | Sort-Object)
+
+          $difference = Compare-Object $expected $present
+          if ($difference) {
+            $names = ($difference | ForEach-Object { $_.InputObject }) -join ', '
+            throw "drivers/ is not the expected package, it differs in: $names"
+          }
+
+          foreach ($catalog in Get-ChildItem drivers -Filter *.cat) {
+            $signature = Get-AuthenticodeSignature $catalog.FullName
+            $subject = $signature.SignerCertificate.Subject
+            Write-Host "$($catalog.Name): $($signature.Status) - $subject"
+
             if ($signature.Status -ne 'Valid') {
-              throw "$($_.Name) is not validly signed: $($signature.Status)"
+              throw "$($catalog.Name) is not validly signed: $($signature.Status)"
+            }
+            if ($subject -notmatch 'Logitech') {
+              throw "$($catalog.Name) is signed by $subject, not by Logitech"
             }
           }
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,193 +1,67 @@
-# Contributing to InputRedirect
+# Instructions for coding agents
 
-InputRedirect is a Windows-only, user-mode program that redirects keyboard and
-mouse input through a real, signed HID driver. It installs the driver, plugs in
-virtual devices, intercepts input with low-level hooks, and re-sends it through
-the driver.
+Read `CONTRIBUTING.md` first. It describes what this program is, where the code
+lives, how one keystroke travels through it, the checks CI runs, the commit and
+pull request conventions, and the parts that are pinned on purpose. All of it
+applies to you.
 
-This means most changes touch one of three things: the Win32/NT boundary, the
-hooks, or the per-event hot path. Read this file before opening a pull request.
+This file adds only what an agent working here gets wrong.
 
-## Where things live
+## You cannot run this program
 
-| Path             | What is in it                                                     |
-| ---------------- | ----------------------------------------------------------------- |
-| `src/main.rs`    | Entry point and exit codes                                        |
-| `src/error.rs`   | The crate's error type; every failure path goes through it        |
-| `src/app/`       | Startup, shutdown, single-instance guard, and the menu actions     |
-| `src/driver/`    | Driver install and removal, virtual devices, IOCTLs, the watchdog  |
-| `src/redirect/`  | The hooks, the decision made per event, echo suppression, combos   |
-| `src/hid/`       | HID report formats, modifier flags, scan code tables               |
-| `src/ui/`        | Console output: layout, colours, the menu, keypress reading        |
-| `drivers/`       | The bundled signed driver package                                  |
-| `res/`           | Application manifest and icon resources                            |
-| `build.rs`       | Embeds the manifest and resources                                  |
-
-## Running it
-
-This is not a program that can be casually run to see what a change does:
-
-- Windows only, on `x86_64`. There is no cross-platform path and no stub.
-- The manifest requires administrator rights, so it will not start elevated by
-  accident - it either runs elevated or exits.
-- It installs a driver package into the system driver store, creates a root
-  device, and can ask for a reboot to finish. Uninstalling is a separate action
-  in the menu, not something that happens on exit.
-
-So verify changes with `cargo test` and CI. Treat an actual run as a deliberate
-act on a machine you are willing to have a driver installed on.
-
-## Before you push
-
-CI runs these, in this order, and fails the build on the first one that
-complains. Run them locally on Windows first:
+It is Windows-only, it requires administrator rights, and it installs a driver.
+These three commands are your whole feedback loop:
 
 ```
 cargo fmt --all --check
 cargo clippy --locked --all-targets -- -D warnings
-cargo test
+cargo test --locked --all-targets
 ```
 
-Notes that catch people out:
+If you could not run them, say so and say which parts are therefore unverified.
+Do not describe a change as working because it looks right.
 
-- **A new Win32 call needs its feature.** The `windows` crate is compiled with
-  an explicit feature list in `Cargo.toml`. Calling an API from a module that
-  is not in that list fails to compile with the item simply not existing - add
-  the feature in the same commit.
-- The `windows` crate is a moving target across versions. An associated
-  function that a tutorial or an older branch uses may no longer exist; check
-  what the pinned version actually provides rather than the name you expect.
-- `--locked` means `Cargo.lock` must already match `Cargo.toml`. Commit the
-  updated lock file together with any dependency change.
-- Clippy runs with `pedantic` and `-D warnings`. Among other things, an item
-  named in a doc comment has to be in backticks.
-- `rustfmt` runs with default settings, so an argument list wider than 60
-  characters gets split across lines even though the line fits in 100.
-- Every commit that lands on the branch should build on its own. Do not split a
-  signature change and its call sites into separate commits.
+## Verify the Win32 surface, do not recall it
 
-## Build configuration
+- The `windows` crate is pinned and its features are listed explicitly in
+  `Cargo.toml`. Check what the pinned version provides instead of the signature
+  you remember, and add the feature in the same commit as the call.
+- A wrong argument or a missing feature shows up as an item that does not exist,
+  not as a helpful error.
+- Behaviour at that boundary is not guessable. If you cannot tell what Windows
+  returns in a case, handle it explicitly rather than assuming.
 
-These are pinned on purpose. A change here changes what ships, so it belongs in
-its own pull request with a reason:
+## Stay inside what was asked
 
-- `rust-toolchain.toml` pins the toolchain, and `Cargo.toml` states the minimum
-  supported version.
-- `.cargo/config.toml` sets the target to `x86_64-pc-windows-msvc` and links
-  the CRT statically, so the release binary runs without a redistributable. CI
-  checks the built executable for dynamic CRT imports.
-- The release profile uses fat LTO, one codegen unit, and strips symbols.
-- CI verifies the Authenticode signature of the bundled driver package.
-
-## Releasing
-
-There are two workflows. `ci.yml` checks and builds every push and pull request
-and keeps the binary as a run artifact; it publishes nothing. `release.yml`
-runs only on a tag and is the only thing that creates a release.
-
-To publish version `X.Y.Z`:
-
-1. Bump `version` in `Cargo.toml`, and the `input-redirect` entry in
-   `Cargo.lock` in the same commit. The lock file is not optional here: CI
-   builds with `--locked` and will fail on a bump that only touched one file.
-2. Merge that through a pull request like any other change.
-3. Tag the merge commit and push the tag:
-
-```
-git tag vX.Y.Z
-git push origin vX.Y.Z
-```
-
-The tag has to match the version in `Cargo.toml`; the workflow refuses to
-publish otherwise, because an archive whose name and whose executable disagree
-about the version is worse than no release. From there it verifies the driver
-signatures, runs the tests, builds, checks the binary really is statically
-linked, packs `InputRedirect.exe` and `LICENSE` into
-`InputRedirect-X.Y.Z-x86_64-windows.zip` with a `.sha256` beside it, and
-publishes a release whose notes are generated from the commits and pull
-requests since the previous tag.
-
-A tag with a suffix - `vX.Y.Z-rc1` - is published as a prerelease.
-
-Nothing here deletes or rewrites a published release. A release that went out
-wrong is superseded by the next tag, not edited in place.
-
-## General requirements
-
-- Keep pull requests small and focused. One concern per pull request; if a
-  change needs a rename or a refactor to make sense, that is its own commit.
-- Explain the issue and why the change fixes it. A diff that only says what it
-  does cannot be reviewed - the reasoning is the part that has to be checked.
-- Before adding new functionality, make sure it does not already exist
-  elsewhere in the codebase. This project has small, purpose-built helpers
-  (path encoding, process lookup, device enumeration, handle wrappers) that are
-  easy to reinvent by accident.
-- English only, everywhere: commit messages, commit bodies, pull request titles
-  and descriptions, code, comments and documentation.
-
-## Pull request titles
-
-Titles follow conventional commit standards:
-
-| Prefix      | Use for                                              |
-| ----------- | ---------------------------------------------------- |
-| `feat:`     | new feature or functionality                         |
-| `fix:`      | bug fix                                              |
-| `docs:`     | documentation or README changes                      |
-| `chore:`    | maintenance tasks, dependency updates, etc.          |
-| `refactor:` | code refactoring without changing behaviour          |
-| `test:`     | adding or updating tests                             |
-
-When a pull request spans several kinds of change, use the prefix that
-describes its purpose, not the largest part of the diff. Individual commits
-within the branch use the same prefixes.
-
-## Code conventions
-
-- `unsafe_op_in_unsafe_fn` is denied. Every `unsafe` block carries a `SAFETY:`
-  comment stating why the call is sound - what owns the handle, who guarantees
-  the pointer, which thread it runs on.
-- Comments explain why, briefly. They are not a narration of the code.
-- Tests are named as sentences describing the property being pinned down, for
-  example `a_plug_refused_while_the_bus_catches_up_is_asked_again`.
-- Prefer RAII wrappers over paired open/close calls, and absolute paths over
-  anything Windows would resolve through `PATH`.
-- The hooks run on the system's input path. Work inside a hook callback is
-  latency for every keystroke on the machine, so nothing goes in there that can
-  block, allocate without need, or call out to Windows unnecessarily.
-- Never let a panic cross an `extern "system"` boundary: unwinding out of a
-  callback aborts the process, and an abort skips the destructors that release
-  the virtual devices.
-
-## The driver interface is not ours to simplify
-
-`src/driver/ioctl.rs` describes a binary interface that belongs to the driver:
-request layouts, field offsets, packing, IOCTL codes, report descriptors, and
-the vendor and product ids the devices are published under. The driver reads
-these bytes at fixed positions.
-
-The assertions in that file are the specification. A layout that looks
-redundant, a padded field, or an odd struct size is the driver's requirement,
-not an oversight. If a change there is genuinely needed, the assertions must be
-updated deliberately and the reason stated - never relaxed to make a build pass.
-
-## Limits on what to change unasked
-
+- One concern per pull request. Do not widen a diff beyond the request; if you
+  notice something adjacent, mention it instead of changing it.
 - Do not edit `README.md` unless the change was asked for.
-- Do not add or upgrade a dependency without the matching `Cargo.lock` update
-  in the same commit.
-- Do not widen a diff beyond what was asked. If you notice something adjacent
-  that should change, say so instead of changing it.
-- Do not merge your own pull request.
+- Do not add or upgrade a dependency without the matching `Cargo.lock` update in
+  the same commit. `cargo` writes that file; it cannot be edited by hand,
+  because the checksums are not something you can produce.
+- Do not merge a pull request.
 
-## Things to leave alone
+## Do not invent what is already decided
 
-These look like oversights and are not. Changing them needs a reason in the
-pull request description:
+- The offsets, sizes and IOCTL codes in `src/driver/ioctl.rs` were read out of
+  one build of the driver. Never relax an assertion to make a build pass.
+- The timeouts, retries and pauses in `src/driver/` were chosen against real
+  hardware behaviour. Leave them unless the change is about them.
+- Small helpers already exist for path encoding, process lookup, device
+  enumeration and handle ownership. Search before adding another.
 
-- The low-level hook architecture, and the choice not to redirect pointer
-  movement or the wheel.
-- The absence of `panic = "abort"` in the release profile.
-- The offset assertions in `src/driver/ioctl.rs`, which pin down the layout the
-  driver expects.
-- The Authenticode verification step in CI.
+## Comments, names and tests
+
+- Every `unsafe` block needs a `SAFETY:` comment saying why it is sound; clippy
+  fails the build without one.
+- Comments say why, briefly, and only where the reason is not in the code. Do
+  not narrate, do not annotate a diff, and do not delete a comment that records
+  how something was found out.
+- Names are words, not letters. Test names are sentences about the property
+  being pinned down.
+- A behaviour change comes with the test that would have caught it.
+
+## English only
+
+Code, comments, documentation, commit messages, pull request titles and
+descriptions.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,7 +128,10 @@ its own pull request with a reason:
   checks the built executable for dynamic CRT imports.
 - The release profile uses fat LTO, one codegen unit, and strips symbols.
 - CI checks that `drivers/` is the expected package, that its catalogues carry
-  a valid Authenticode signature, and that Logitech is what signed them.
+  a valid signature from the Windows Hardware Compatibility Publisher - which
+  is the signature a kernel driver needs, and the only one it can have, since
+  the vendor submits the package and Microsoft signs it - and that the INF files
+  name Logitech as the vendor.
 
 ## Pull requests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,236 @@
+# Contributing to InputRedirect
+
+InputRedirect is a Windows-only, user-mode program that redirects keyboard and
+mouse input through a real, signed HID driver. It installs the driver, plugs in
+virtual devices, intercepts input with low-level hooks, and re-sends it through
+the driver.
+
+This means most changes touch one of three things: the Win32/NT boundary, the
+hooks, or the per-event hot path. Read this file before opening a pull request.
+
+## Reporting an issue
+
+A report is only useful if it can be told apart from a machine-specific
+problem, so include:
+
+- The Windows build, and whether Memory integrity (HVCI) is on.
+- What the program printed. Every failure goes through one error type and comes
+  out as a sentence on the console; that sentence is the most useful line in the
+  report.
+- Whether Logitech G HUB or another Logitech driver was installed beforehand.
+- What you did, what you expected, and what happened instead.
+
+Anti-cheat software blocking the driver is expected rather than a bug; see the
+Compatibility section of the README.
+
+## Where things live
+
+| Path             | What is in it                                                     |
+| ---------------- | ----------------------------------------------------------------- |
+| `src/main.rs`    | Entry point and exit codes                                        |
+| `src/error.rs`   | The crate's error type; every failure path goes through it        |
+| `src/app/`       | Startup, shutdown, single-instance guard, and the menu actions     |
+| `src/driver/`    | Driver install and removal, virtual devices, IOCTLs, the watchdog  |
+| `src/redirect/`  | The hooks, the decision made per event, echo suppression, combos   |
+| `src/hid/`       | HID report formats, modifier flags, scan code tables               |
+| `src/ui/`        | Console output: layout, colours, the menu, keypress reading        |
+| `drivers/`       | The bundled signed driver package                                  |
+| `res/`           | Application manifest and icon resources                            |
+| `build.rs`       | Embeds the manifest and resources                                  |
+
+## How one keystroke travels
+
+The shortest path into the codebase is to follow a single key press through it.
+
+1. **The hook receives it.** `src/redirect/hook.rs` installs a low-level
+   keyboard and mouse hook on a thread of its own and runs a message loop there,
+   because that is how Windows delivers hook callbacks. The hooks are installed
+   again periodically: Windows drops a hook whose callback took too long, and it
+   does not say so.
+2. **The engine decides.** `src/redirect/mod.rs` turns the event into one of a
+   few outcomes: pass it through, swallow it, or send it through the driver. The
+   decision is a plain function over the event, which is why it is the part with
+   the most tests.
+3. **Our own echo is let through.** The virtual keyboard is a real HID device,
+   so a report we send arrives back at our own hook a moment later.
+   `src/redirect/echo.rs` recognises it and passes it on untouched - without
+   that, the first keystroke would go round for ever.
+4. **Modifiers stay on the physical path.** They are not events of their own to
+   the driver: they ride along in the same report as the key they modify, which
+   `src/redirect/combo.rs` keeps track of. Redirecting them separately would
+   break every shortcut.
+5. **The report is built.** `src/hid/` turns the event into the bytes a device
+   sends: `scancode.rs` maps the key to its HID usage, `keyboard.rs` fills the
+   eight-byte report with its modifier byte and six key slots, `mouse.rs` the
+   five-byte one. Nothing here knows about Windows, so it is fully covered by
+   tests and the easiest place to start reading.
+6. **The driver sends it.** `src/driver/ioctl.rs` holds the request layout,
+   `src/driver/device.rs` the open handle. The original event is swallowed, so
+   the application only ever sees the one that came from the virtual device.
+
+Pointer movement and the wheel are deliberately not redirected: they carry no
+information an application checks the device for, and passing them through the
+driver only adds latency and jitter to the pointer.
+
+## Running it
+
+This is not a program that can be casually run to see what a change does:
+
+- Windows only, on `x86_64`. There is no cross-platform path and no stub.
+- The manifest requires administrator rights, so it will not start elevated by
+  accident - it either runs elevated or exits.
+- It installs a driver package into the system driver store, creates a root
+  device, and can ask for a reboot to finish. Uninstalling is a separate action
+  in the menu, not something that happens on exit.
+
+So verify changes with `cargo test` and CI. Treat an actual run as a deliberate
+act on a machine you are willing to have a driver installed on.
+
+## Before you push
+
+CI runs these, in this order, and fails the build on the first one that
+complains. Run them locally on Windows first:
+
+```
+cargo fmt --all --check
+cargo clippy --locked --all-targets -- -D warnings
+cargo test --locked --all-targets
+```
+
+Notes that catch people out:
+
+- **A new Win32 call needs its feature.** The `windows` crate is compiled with
+  an explicit feature list in `Cargo.toml`. Calling an API from a module that
+  is not in that list fails to compile with the item simply not existing - add
+  the feature in the same commit.
+- The `windows` crate is a moving target across versions. An associated
+  function that a tutorial or an older branch uses may no longer exist; check
+  what the pinned version actually provides rather than the name you expect.
+- `--locked` means `Cargo.lock` must already match `Cargo.toml`. Commit the
+  updated lock file together with any dependency change.
+- Clippy runs with `pedantic` and `-D warnings`. Among other things, an item
+  named in a doc comment has to be in backticks, and every `unsafe` block needs
+  a `SAFETY:` comment.
+- `rustfmt` runs with default settings, so an argument list wider than 60
+  characters gets split across lines even though the line fits in 100.
+- Every commit that lands on the branch should build on its own. Do not split a
+  signature change and its call sites into separate commits.
+
+## Build configuration
+
+These are pinned on purpose. A change here changes what ships, so it belongs in
+its own pull request with a reason:
+
+- `rust-toolchain.toml` pins the toolchain, and `Cargo.toml` states the minimum
+  supported version.
+- `.cargo/config.toml` sets the target to `x86_64-pc-windows-msvc` and links
+  the CRT statically, so the release binary runs without a redistributable. CI
+  checks the built executable for dynamic CRT imports.
+- The release profile uses fat LTO, one codegen unit, and strips symbols.
+- CI checks that `drivers/` is the expected package, that its catalogues carry
+  a valid Authenticode signature, and that Logitech is what signed them.
+
+## Pull requests
+
+- Keep pull requests small and focused. One concern per pull request; if a
+  change needs a rename or a refactor to make sense, that is its own commit.
+- Explain the issue and why the change fixes it. A diff that only says what it
+  does cannot be reviewed - the reasoning is the part that has to be checked.
+- Before adding new functionality, make sure it does not already exist
+  elsewhere in the codebase. This project has small, purpose-built helpers
+  (path encoding, process lookup, device enumeration, handle wrappers) that are
+  easy to reinvent by accident.
+- English only, everywhere: commit messages, commit bodies, pull request titles
+  and descriptions, code, comments and documentation.
+
+Titles follow conventional commit standards:
+
+| Prefix      | Use for                                              |
+| ----------- | ---------------------------------------------------- |
+| `feat:`     | new feature or functionality                         |
+| `fix:`      | bug fix                                              |
+| `docs:`     | documentation or README changes                      |
+| `chore:`    | maintenance tasks, dependency updates, etc.          |
+| `refactor:` | code refactoring without changing behaviour          |
+| `test:`     | adding or updating tests                             |
+
+When a pull request spans several kinds of change, use the prefix that
+describes its purpose, not the largest part of the diff. Individual commits
+within the branch use the same prefixes.
+
+## Code conventions
+
+- `unsafe_op_in_unsafe_fn` is denied. Every `unsafe` block carries a `SAFETY:`
+  comment stating why the call is sound - what owns the handle, who guarantees
+  the pointer, which thread it runs on.
+- Comments explain why, briefly. They are not a narration of the code.
+- Names are words, not letters. Tests are named as sentences describing the
+  property being pinned down, for example
+  `a_plug_refused_while_the_bus_catches_up_is_asked_again`.
+- Prefer RAII wrappers over paired open/close calls, and absolute paths over
+  anything Windows would resolve through `PATH`.
+- The hooks run on the system's input path. Work inside a hook callback is
+  latency for every keystroke on the machine, so nothing goes in there that can
+  block, allocate without need, or call out to Windows unnecessarily.
+- Never let a panic cross an `extern "system"` boundary: unwinding out of a
+  callback aborts the process, and an abort skips the destructors that release
+  the virtual devices.
+
+## The driver interface is not ours to simplify
+
+`src/driver/ioctl.rs` describes a binary interface that belongs to the driver:
+request layouts, field offsets, packing, IOCTL codes, report descriptors, and
+the vendor and product ids the devices are published under. The driver reads
+these bytes at fixed positions.
+
+The assertions in that file are the specification. A layout that looks
+redundant, a padded field, or an odd struct size is the driver's requirement,
+not an oversight. If a change there is genuinely needed, the assertions must be
+updated deliberately and the reason stated - never relaxed to make a build pass.
+
+## Things to leave alone
+
+These look like oversights and are not. Changing them needs a reason in the
+pull request description:
+
+- The low-level hook architecture, and the choice not to redirect pointer
+  movement or the wheel.
+- The absence of `panic = "abort"` in the release profile.
+- The offset assertions in `src/driver/ioctl.rs`, which pin down the layout the
+  driver expects.
+- The driver verification step in CI.
+- Installing the driver and closing G HUB without asking. Both are what the
+  program is for, and neither affects other Logitech devices.
+
+## Releasing
+
+There are two workflows. `ci.yml` checks and builds every push and pull request
+and keeps the binary as a run artifact; it publishes nothing. `release.yml`
+runs only on a tag and is the only thing that creates a release.
+
+To publish version `X.Y.Z`:
+
+1. Bump `version` in `Cargo.toml`, and the `input-redirect` entry in
+   `Cargo.lock` in the same commit. The lock file is not optional here: CI
+   builds with `--locked` and will fail on a bump that only touched one file.
+2. Merge that through a pull request like any other change.
+3. Tag the merge commit and push the tag:
+
+```
+git tag vX.Y.Z
+git push origin vX.Y.Z
+```
+
+The tag has to match the version in `Cargo.toml`; the workflow refuses to
+publish otherwise, because an archive whose name and whose executable disagree
+about the version is worse than no release. From there it verifies the driver
+files, runs the tests, builds, checks the binary really is statically linked,
+packs `InputRedirect.exe` and `LICENSE` into
+`InputRedirect-X.Y.Z-x86_64-windows.zip` with a `.sha256` beside it, and
+publishes a release whose notes are generated from the commits and pull
+requests since the previous tag.
+
+A tag with a suffix - `vX.Y.Z-rc1` - is published as a prerelease.
+
+Nothing here deletes or rewrites a published release. A release that went out
+wrong is superseded by the next tag, not edited in place.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
+name = "bytemuck"
+version = "1.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f65693059b6b9c588b9f62fed1cedbf0a8b805631457ea162d68f0de186f3de5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "cc"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -98,6 +118,7 @@ name = "input-redirect"
 version = "0.1.0"
 dependencies = [
  "bitflags",
+ "bytemuck",
  "embed-resource",
  "tempfile",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,10 @@ unsafe_op_in_unsafe_fn = "deny"
 all = { level = "warn", priority = -1 }
 pedantic = { level = "warn", priority = -1 }
 
+# Every unsafe block here already says why it is sound. The lint keeps it that
+# way: a block without its reasoning is a block nobody can review.
+undocumented_unsafe_blocks = "warn"
+
 # The Win32 surface is casts and wide pointers throughout; forbidding them
 # would only add noise to calls we cannot write any other way.
 cast_possible_truncation = "allow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/main.rs"
 
 [dependencies]
 bitflags = "2"
+bytemuck = { version = "1.25.2", features = ["derive"] }
 tempfile = "3"
 thiserror = "2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ features = [
     "Win32_System_Registry",
     "Win32_System_RestartManager",
     "Win32_System_Services",
+    "Win32_System_SystemInformation",
     "Win32_System_Threading",
     "Win32_UI_Input_KeyboardAndMouse",
     "Win32_UI_Shell",

--- a/src/driver/device.rs
+++ b/src/driver/device.rs
@@ -71,9 +71,12 @@ pub struct Devices {
 }
 
 // SAFETY: the handle is an opaque kernel handle rather than a pointer into this
-// process, and the driver serialises the requests it receives. The hook thread
-// and the interface thread may therefore share one connection.
+// process, so nothing in this type is tied to the thread that opened it.
 unsafe impl Send for Devices {}
+
+// SAFETY: the driver serialises the requests it receives, and every method here
+// takes the connection by shared reference and mutates nothing behind it. The
+// hook thread and the interface thread may therefore share one connection.
 unsafe impl Sync for Devices {}
 
 impl Devices {

--- a/src/driver/ioctl.rs
+++ b/src/driver/ioctl.rs
@@ -7,6 +7,7 @@
 
 use std::mem::{offset_of, size_of};
 
+use bytemuck::{Pod, Zeroable};
 use windows::Wdk::System::IO::NtDeviceIoControlFile;
 use windows::Win32::Foundation::{HANDLE, NTSTATUS};
 use windows::Win32::System::IO::IO_STATUS_BLOCK;
@@ -32,8 +33,12 @@ const HARDWARE_ID_SIZE: usize = HARDWARE_ID_TEMPLATE.len() * 2 + 4;
 
 /// What the driver expects at the front of a plug request. The report
 /// descriptor follows immediately after it.
+///
+/// `Pod` is what makes the layout the compiler's problem rather than a comment's:
+/// it cannot be derived for a type with padding, which is exactly the property
+/// that has to hold for the bytes to mean to the driver what they mean here.
 #[repr(C, packed)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Pod, Zeroable)]
 pub struct PlugRequest {
     magic: u32,
     pub device_id: u32,
@@ -49,27 +54,6 @@ pub struct PlugRequest {
     report_descriptor_size: u32,
 }
 
-impl Default for PlugRequest {
-    /// Written out by hand because arrays longer than 32 elements have no
-    /// `Default` of their own, and the hardware id field is 128 bytes wide.
-    fn default() -> Self {
-        Self {
-            magic: 0,
-            device_id: 0,
-            flag: 0,
-            hardware_id_size: 0,
-            hardware_id: [0; 0x80],
-            vendor_id: 0,
-            product_id: 0,
-            device_kind: 0,
-            version: 0,
-            _padding: 0,
-            _reserved: [0; 0xB2 - 0x9C],
-            report_descriptor_size: 0,
-        }
-    }
-}
-
 const _: () = assert!(size_of::<PlugRequest>() == 0xB6);
 const _: () = assert!(offset_of!(PlugRequest, hardware_id) == 0x10);
 const _: () = assert!(offset_of!(PlugRequest, vendor_id) == 0x90);
@@ -80,7 +64,7 @@ const _: () = assert!(offset_of!(PlugRequest, report_descriptor_size) == 0xB2);
 const _: () = assert!(HARDWARE_ID_SIZE <= 0x80);
 
 #[repr(C, packed)]
-#[derive(Clone, Copy, Default)]
+#[derive(Clone, Copy, Pod, Zeroable)]
 pub struct UnplugRequest {
     size: u32,
     device_id: u32,
@@ -99,7 +83,7 @@ impl UnplugRequest {
 
     #[must_use]
     pub fn as_bytes(&self) -> Vec<u8> {
-        as_bytes(self)
+        bytemuck::bytes_of(self).to_vec()
     }
 }
 
@@ -168,11 +152,11 @@ pub fn plug_payload(kind: DeviceKind) -> Vec<u8> {
         device_kind: kind.code(),
         version: 0x0100,
         report_descriptor_size: descriptor.len() as u32,
-        ..PlugRequest::default()
+        ..PlugRequest::zeroed()
     };
     header.hardware_id[..hardware_id_bytes.len()].copy_from_slice(&hardware_id_bytes);
 
-    let mut payload = as_bytes(&header);
+    let mut payload = bytemuck::bytes_of(&header).to_vec();
     payload.extend_from_slice(descriptor);
     payload
 }
@@ -188,14 +172,6 @@ pub fn plugged_device_id(payload: &[u8]) -> u32 {
         .get(4..8)
         .and_then(|bytes| <[u8; 4]>::try_from(bytes).ok())
         .map_or(0, u32::from_le_bytes)
-}
-
-fn as_bytes<T: Copy>(value: &T) -> Vec<u8> {
-    // SAFETY: T is a plain packed structure with no padding to leak and no
-    // pointers; reading it as bytes is exactly what the driver expects.
-    unsafe {
-        std::slice::from_raw_parts(std::ptr::from_ref(value).cast::<u8>(), size_of::<T>()).to_vec()
-    }
 }
 
 /// Sends one request to the driver.

--- a/src/driver/ioctl.rs
+++ b/src/driver/ioctl.rs
@@ -22,6 +22,14 @@ pub const VENDOR_ID: u16 = 0x046D;
 pub const KEYBOARD_PRODUCT_ID: u16 = 0xC232;
 pub const MOUSE_PRODUCT_ID: u16 = 0xC231;
 
+/// The hardware id the driver matches on, in the longest form it can take: both
+/// ids are always written as four hex digits, so every device's id is this wide.
+const HARDWARE_ID_TEMPLATE: &str = r"LGHUBDevice\VID_0000&PID_0000";
+
+/// The same as UTF-16, with the two trailing zero units the driver reads as the
+/// end of a double null terminated string.
+const HARDWARE_ID_SIZE: usize = HARDWARE_ID_TEMPLATE.len() * 2 + 4;
+
 /// What the driver expects at the front of a plug request. The report
 /// descriptor follows immediately after it.
 #[repr(C, packed)]
@@ -69,6 +77,7 @@ const _: () = assert!(offset_of!(PlugRequest, product_id) == 0x92);
 const _: () = assert!(offset_of!(PlugRequest, device_kind) == 0x94);
 const _: () = assert!(offset_of!(PlugRequest, version) == 0x98);
 const _: () = assert!(offset_of!(PlugRequest, report_descriptor_size) == 0xB2);
+const _: () = assert!(HARDWARE_ID_SIZE <= 0x80);
 
 #[repr(C, packed)]
 #[derive(Clone, Copy, Default)]
@@ -138,6 +147,7 @@ pub fn plug_payload(kind: DeviceKind) -> Vec<u8> {
     let descriptor = kind.report_descriptor();
 
     // The driver matches on this hardware id when it creates the child device.
+    // Its length is the one HARDWARE_ID_TEMPLATE stands for.
     let hardware_id: Vec<u16> = format!("LGHUBDevice\\VID_{VENDOR_ID:04X}&PID_{product_id:04X}")
         .encode_utf16()
         .collect();
@@ -145,6 +155,7 @@ pub fn plug_payload(kind: DeviceKind) -> Vec<u8> {
         .iter()
         .flat_map(|unit| unit.to_le_bytes())
         .collect();
+    debug_assert_eq!(hardware_id_bytes.len() + 4, HARDWARE_ID_SIZE);
 
     let mut header = PlugRequest {
         magic: 0xB7,
@@ -360,6 +371,18 @@ mod tests {
             &payload[0x10 + declared - 4..0x10 + declared],
             &[0, 0, 0, 0]
         );
+    }
+
+    /// The field is 128 bytes and the id is built at run time, so the id of
+    /// every device has to be the length the compile time assertion is about.
+    #[test]
+    fn the_hardware_id_of_both_devices_is_the_length_that_was_checked() {
+        for kind in [DeviceKind::Keyboard, DeviceKind::Mouse] {
+            let payload = plug_payload(kind);
+            let declared = u32::from_le_bytes(payload[0x0C..0x10].try_into().unwrap()) as usize;
+
+            assert_eq!(declared, HARDWARE_ID_SIZE, "{} id", kind.label());
+        }
     }
 
     #[test]

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -623,9 +623,35 @@ pub(crate) fn wide_path(path: &Path) -> Vec<u16> {
 /// file name: that resolves through PATH, and a writable directory ahead of
 /// System32 would decide what an administrator runs.
 pub(crate) fn system32(program: &str) -> PathBuf {
-    let root = std::env::var_os("SystemRoot").unwrap_or_else(|| OsString::from(r"C:\Windows"));
+    system_directory().join(program)
+}
 
-    Path::new(&root).join("System32").join(program)
+/// The system directory, as Windows itself reports it.
+///
+/// Not `%SystemRoot%`: the environment is inherited from whoever started this
+/// process, and an elevated process must not take the location of the programs
+/// it runs - or of the driver files it compares - from something its parent was
+/// free to set.
+pub(crate) fn system_directory() -> PathBuf {
+    use std::os::windows::ffi::OsStringExt;
+
+    use windows::Win32::Foundation::MAX_PATH;
+    use windows::Win32::System::SystemInformation::GetSystemDirectoryW;
+
+    let mut buffer = [0u16; MAX_PATH as usize];
+
+    // SAFETY: the call is given the real length of the buffer and writes no
+    // more than that.
+    let written = unsafe { GetSystemDirectoryW(Some(&mut buffer)) } as usize;
+
+    // Zero means the call failed, and a length past the end means the path did
+    // not fit and nothing was written. Neither can be answered with anything
+    // better than the place Windows is installed in on every machine we run on.
+    if written == 0 || written > buffer.len() {
+        return PathBuf::from(r"C:\Windows\System32");
+    }
+
+    PathBuf::from(OsString::from_wide(&buffer[..written]))
 }
 
 #[cfg(test)]
@@ -687,6 +713,16 @@ mod tests {
             .to_string_lossy()
             .to_lowercase()
             .contains(r"system32\pnputil.exe"));
+    }
+
+    /// Windows answers with the directory it actually loads its programs from,
+    /// whatever the environment says.
+    #[test]
+    fn the_system_directory_is_an_absolute_path_ending_in_system32() {
+        let path = system_directory();
+
+        assert!(path.is_absolute());
+        assert!(path.ends_with("System32") || path.ends_with("system32"));
     }
 
     #[test]

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -770,7 +770,7 @@ mod tests {
     /// When the bus is already empty the function must not sit out the timeout:
     /// the promptness check only applies to that case. When there are leftover
     /// devices (driver installed in another window) the function correctly waits
-    /// out REMOVAL_TIMEOUT, and no timing assertion makes sense.
+    /// out `REMOVAL_TIMEOUT`, and no timing assertion makes sense.
     #[test]
     fn an_empty_bus_is_noticed_without_waiting() {
         let started = Instant::now();

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -767,15 +767,18 @@ mod tests {
         assert_eq!(attempts, PLUG_ATTEMPTS);
     }
 
-    /// The wait has to answer, not sit out its timeout. Whether the bus is
-    /// empty depends on the machine - our own program may be running in another
-    /// window - so only the promptness is asserted.
+    /// When the bus is already empty the function must not sit out the timeout:
+    /// the promptness check only applies to that case. When there are leftover
+    /// devices (driver installed in another window) the function correctly waits
+    /// out REMOVAL_TIMEOUT, and no timing assertion makes sense.
     #[test]
     fn an_empty_bus_is_noticed_without_waiting() {
         let started = Instant::now();
-        let _ = wait_for_empty_bus();
+        let empty = wait_for_empty_bus();
 
-        assert!(started.elapsed() < REMOVAL_TIMEOUT);
+        if empty {
+            assert!(started.elapsed() < REMOVAL_TIMEOUT);
+        }
     }
 
     /// The message shown when nothing worked has to read as a sentence.

--- a/src/driver/version.rs
+++ b/src/driver/version.rs
@@ -9,7 +9,7 @@
 //! those two apart from the outside, so the version is compared beforehand and
 //! the build this program was written against is the one that runs.
 
-use std::ffi::{c_void, OsString};
+use std::ffi::c_void;
 use std::fmt;
 use std::mem::size_of;
 use std::path::{Path, PathBuf};
@@ -19,7 +19,7 @@ use windows::Win32::Storage::FileSystem::{
     GetFileVersionInfoSizeW, GetFileVersionInfoW, VerQueryValueW, VS_FIXEDFILEINFO,
 };
 
-use super::wide;
+use super::{system_directory, wide};
 
 /// The three binaries the package installs.
 ///
@@ -74,9 +74,7 @@ pub fn installed_binaries() -> Vec<PathBuf> {
 
 /// Where Windows keeps the copy of a driver binary it loads.
 fn installed_path(name: &str) -> PathBuf {
-    let root = std::env::var_os("SystemRoot").unwrap_or_else(|| OsString::from(r"C:\Windows"));
-
-    Path::new(&root).join("System32").join("drivers").join(name)
+    system_directory().join("drivers").join(name)
 }
 
 /// The four numbers Windows shows as the file version of a driver.

--- a/src/redirect/hook.rs
+++ b/src/redirect/hook.rs
@@ -242,6 +242,8 @@ fn decided_safely(decide: impl FnOnce() -> Decision) -> Decision {
 
 unsafe extern "system" fn keyboard_hook(code: i32, event: WPARAM, data: LPARAM) -> LRESULT {
     if code < 0 {
+        // SAFETY: the arguments are handed back exactly as Windows passed them
+        // in, and None asks it to find the next hook in the chain itself.
         return unsafe { CallNextHookEx(None, code, event, data) };
     }
 
@@ -259,11 +261,14 @@ unsafe extern "system" fn keyboard_hook(code: i32, event: WPARAM, data: LPARAM) 
         return SWALLOWED;
     }
 
+    // SAFETY: as above - the event travels on untouched.
     unsafe { CallNextHookEx(None, code, event, data) }
 }
 
 unsafe extern "system" fn mouse_hook(code: i32, event: WPARAM, data: LPARAM) -> LRESULT {
     if code < 0 {
+        // SAFETY: the arguments are handed back exactly as Windows passed them
+        // in, and None asks it to find the next hook in the chain itself.
         return unsafe { CallNextHookEx(None, code, event, data) };
     }
 
@@ -276,6 +281,7 @@ unsafe extern "system" fn mouse_hook(code: i32, event: WPARAM, data: LPARAM) -> 
         }
     }
 
+    // SAFETY: as above - the event travels on untouched.
     unsafe { CallNextHookEx(None, code, event, data) }
 }
 


### PR DESCRIPTION
- **fix: ask Windows for the system directory**
- **test: check that the hardware id fits the field it is copied into**
- **chore: make the SAFETY comment on an unsafe block a rule**
- **chore: check who signed the drivers and watch the dependencies**
- **docs: split the contributor guide from the agent instructions**
- **fix: expect the WHQL signer on the driver catalogues**
- **docs: say what the driver check actually checks**
- **chore: document the unsafe blocks the new lint found**
- **refactor: let the compiler check the request layouts**
- **test: skip the promptness check when the bus is not empty**
